### PR TITLE
New post title placeholder, Bunch of Issues with render, diff, DOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ✍ filbert
+# ✍️ filbert
 ## a simple writing platform
 ### monorepo for https://filbert.xyz and (for now) my personal site https://dubaniewi.cz
 #### Tech Stack:

--- a/USEFUL_COMMANDS.md
+++ b/USEFUL_COMMANDS.md
@@ -14,7 +14,7 @@ docker-compose up -d db
 export PERCONA_CONTAINER_NAME="${PWD##*/}_db_1"
 
 # DB backup
-docker exec $PERCONA_CONTAINER_NAME /usr/bin/mysqldump --default-character-set=utf8mb4 --databases dubaniewicz -uroot -p"$MYSQL_ROOT_PASSWORD" > ~/Dropbox/mysql\ dumps/`date +'%Y-%m-%d_%H%M'`.sql
+docker exec $PERCONA_CONTAINER_NAME /usr/bin/mysqldump --default-character-set=utf8mb4 --databases filbert -uroot -p"$MYSQL_ROOT_PASSWORD" > ~/Dropbox/mysql\ dumps/`date +'%Y-%m-%d_%H%M'`.sql
 
 # DB restore
 docker exec -i $PERCONA_CONTAINER_NAME /usr/bin/mysql -uroot -p"$MYSQL_ROOT_PASSWORD" < ~/Dropbox/mysql\ dumps/2019-07-07_1032.sql

--- a/api/README.md
+++ b/api/README.md
@@ -1,1 +1,1 @@
-# ✍️ filbert API
+# ✍️️ filbert API

--- a/api/README.md
+++ b/api/README.md
@@ -1,1 +1,1 @@
-# dubaniewicz-backend
+# ✍️ filbert API

--- a/api/mysql.js
+++ b/api/mysql.js
@@ -10,7 +10,7 @@ export async function getKnex() {
         host: process.env.NODE_ENV === 'production' ? 'db' : 'localhost', // docker-compose.yml service name
         user: 'root',
         password: process.env.MYSQL_ROOT_PASSWORD,
-        database: 'dubaniewicz'
+        database: 'filbert'
       },
       asyncStackTraces: true,
       debug: true,

--- a/api/package.json
+++ b/api/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "dubaniewicz-backend",
+  "name": "filbert-backend",
   "version": "0.0.1",
   "description": "Node.js Express API w/ MySQL",
   "main": "index.js",
-  "repository": "git@github.com:bc-jasond/dubaniewicz-backend.git",
-  "author": "Jason Dubaniewicz <jasondebo@gmail.com>",
+  "repository": "git@github.com:bc-jasond/filbert.git",
+  "author": "Jason Dubaniewicz <jason@dubaniewi.cz>",
   "license": "MIT",
   "scripts": {
     "watch": ". ../dev.env && nodemon ./index.js localhost 3001",
     "start": "node ./index.js",
-    "docker-build": "docker build --tag=dubaniewicz-api:`git log -1 --pretty=format:%h` .",
-    "docker-run": "docker run -p 3001:3001 dubaniewicz-api:`git log -1 --pretty=format:%h`"
+    "docker-build": "docker build --tag=filbert-api:`git log -1 --pretty=format:%h` .",
+    "docker-run": "docker run -p 3001:3001 filbert-api:`git log -1 --pretty=format:%h`"
   },
   "devDependencies": {
     "nodemon": "^1.18.11"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "a simple writing platform",
   "main": "index.html",
-  "repository": "https://github.com/bc-jasond/dubaniewicz-site.git",
+  "repository": "https://github.com/bc-jasond/filbert.git",
   "author": "Jason Dubaniewicz <jason@dubaniewi.cz>",
   "license": "MIT",
   "private": null,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,7 +26,7 @@
     "html-webpack-plugin": "^3.2.0",
     "immutable": "^4.0.0-rc.12",
     "react": "^16.10.2",
-    "react-dom": "^16.10.2",
+    "react-dom": "npm:@hot-loader/react-dom",
     "react-hot-loader": "^4.12.15",
     "react-router-dom": "^5.1.2",
     "styled-components": "^4.4.0",

--- a/frontend/src/common/constants.js
+++ b/frontend/src/common/constants.js
@@ -88,8 +88,8 @@ export const POST_ACTION_REDIRECT_TIMEOUT = 1000;
 export const API_URL = process.env.API_URL;
 
 // AUTH
-export const AUTH_TOKEN_KEY = 'dubaniewicz-token';
-export const SESSION_KEY = 'dubaniewicz-session';
+export const AUTH_TOKEN_KEY = 'filbert-token';
+export const SESSION_KEY = 'filbert-session';
 
 // DOM
 export const DOM_TEXT_NODE_TYPE_ID = 3;

--- a/frontend/src/common/constants.js
+++ b/frontend/src/common/constants.js
@@ -81,6 +81,8 @@ export const SELECTION_ACTION_LINK = 'selection-link';
 export const SELECTION_ACTION_H1 = 'selection-h1';
 export const SELECTION_ACTION_H2 = 'selection-h2';
 export const SELECTION_LINK_URL = 'linkUrl';
+export const SELECTION_START = 'start';
+export const SELECTION_END = 'end';
 // post level edits
 export const POST_ACTION_REDIRECT_TIMEOUT = 1000;
 

--- a/frontend/src/common/constants.js
+++ b/frontend/src/common/constants.js
@@ -81,6 +81,8 @@ export const SELECTION_ACTION_LINK = 'selection-link';
 export const SELECTION_ACTION_H1 = 'selection-h1';
 export const SELECTION_ACTION_H2 = 'selection-h2';
 export const SELECTION_LINK_URL = 'linkUrl';
+// post level edits
+export const POST_ACTION_REDIRECT_TIMEOUT = 1000;
 
 // ENV
 export const API_URL = process.env.API_URL;

--- a/frontend/src/common/content-node.component.jsx
+++ b/frontend/src/common/content-node.component.jsx
@@ -55,6 +55,7 @@ import {
   cleanTextOrZeroLengthPlaceholder,
   imageUrlIsId,
 } from './utils';
+import {getCaretNode} from "./dom";
 
 const StyledDiv = styled.div``;
 
@@ -91,7 +92,7 @@ export default class ContentNode extends React.Component {
         <ContentNode key={child.get('id')} post={post} node={child} nodesByParentId={nodesByParentId}
                      isEditing={isEditing} />))
   }
-  
+
   shouldComponentUpdate(nextProps) {
     const {
       node,
@@ -111,7 +112,7 @@ export default class ContentNode extends React.Component {
   }
   
   render() {
-    console.log("ContentNode RENDER", this);
+    console.debug("ContentNode RENDER", this);
     const {
       post,
       node,

--- a/frontend/src/common/dom.js
+++ b/frontend/src/common/dom.js
@@ -55,7 +55,7 @@ export function setCaret(nodeId, offset = -1, shouldFindLastNode = false) {
     const queue = [...containerNode.childNodes];
     while (queue.length) {
       if (infiniteLoopCount++ > 1000) {
-        throw new Error('setCaret is Out of Control!!!');
+        throw new Error('setCaret is Fuera de Control!!!');
       }
       // find first (queue), find last - (stack) yay!
       const current = shouldFindLastNode ? queue.pop() : queue.shift();
@@ -71,8 +71,7 @@ export function setCaret(nodeId, offset = -1, shouldFindLastNode = false) {
   if (textNode) {
     console.info('setCaret textNode ', textNode, ' offset ', offset);
     // set caret to end of text content
-    range.setEnd(textNode, offset === -1 ? textNode.textContent.length : offset);
-    range.collapse();
+    range.setStart(textNode, offset === -1 ? textNode.textContent.length : offset);
     sel.addRange(range);
   } else {
     console.warn(`setCaret - couldn't find a text node inside of `, nodeId);

--- a/frontend/src/common/fonts.css.js
+++ b/frontend/src/common/fonts.css.js
@@ -6,11 +6,11 @@ import CharterItalic from '../../assets/fonts/charter-italic-webfont.woff';
 import Kievit from '../../assets/fonts/kievit-ot-book.woff';
 import FiraCode from '../../assets/fonts/fira-code-regular.woff';
 
-export const titleSerif = 'dubaniewicz-title-serif';
-export const contentSerif = 'dubaniewicz-content-serif';
-export const italicSerif = 'dubaniewicz-italic-serif';
-export const sansSerif = 'dubaniewicz-sans-serif';
-export const monospaced = 'dubaniewicz-monospace';
+export const titleSerif = 'filbert-title-serif';
+export const contentSerif = 'filbert-content-serif';
+export const italicSerif = 'filbert-italic-serif';
+export const sansSerif = 'filbert-sans-serif';
+export const monospaced = 'filbert-monospace';
 
 export default createGlobalStyle`
     @font-face {

--- a/frontend/src/common/shared-styled-components.jsx
+++ b/frontend/src/common/shared-styled-components.jsx
@@ -13,6 +13,13 @@ export const H1 = styled.h1`
   font-size: 46px;
   line-height: 1.25;
   margin-bottom: 24px;
+  ${p => p.shouldShowPlaceholder && `
+    &::before {
+      content: 'Write a title and hit enter...';
+      position: absolute;
+      color: ${mediumGrey};
+    }
+  `}
 `;
 export const H2 = styled.h2`
  ${sectionWidthMixin}
@@ -335,7 +342,7 @@ export const LilBlackMenu = styled.div`
   position: absolute;
   transition: .1s top;
   top: ${p => p.top}px;
-  z-index: 11;
+  z-index: 13;
   background-image: linear-gradient(to bottom,rgba(49,49,47,.99),#262625);
   background-repeat: repeat-x;
   border-radius: 5px;

--- a/frontend/src/common/utils.js
+++ b/frontend/src/common/utils.js
@@ -42,11 +42,12 @@ export function cleanText(text) {
     //
 }
 
-export function normalizeSpaces(text) {
+export function normalizeHtmlEntities(text) {
+  // TODO: what other htmlentities need to be normalized here?
   // for pesky char code 160 ( &nbsp; )
   // contenteditable automatically converts between " " 32 and "&nbsp;" 160 for placeholder spaces at the end of tags or sequential spaces
   // we want to normalize this (to 32) for diffing
-  return text.replace(/\s+/g, " ");
+  return text.replace(String.fromCharCode(160), String.fromCharCode(32));
 }
 
 export function getDiffStartAndLength(oldStr, newStr) {
@@ -55,8 +56,8 @@ export function getDiffStartAndLength(oldStr, newStr) {
   const loopLength = Math.max(newStr.length, oldStr.length);
   
   for (let i = 0; i < loopLength; i++) {
-    let oldCurrent = normalizeSpaces(oldStr).charAt(i);
-    let newCurrent = normalizeSpaces(newStr).charAt(i);
+    let oldCurrent = normalizeHtmlEntities(oldStr).charAt(i);
+    let newCurrent = normalizeHtmlEntities(newStr).charAt(i);
     if (oldCurrent.length === 0) {
       // chars were added to the end
       return [i, diffLength];

--- a/frontend/src/jason.html
+++ b/frontend/src/jason.html
@@ -36,6 +36,6 @@
 </head>
 <body>
  <h1>Hi.</h1>
- <p>Try ✍ <a href="https://filbert.xyz">filbert️</a></p>
+ <p>Try ✍️ <a href="https://filbert.xyz">filbert️</a></p>
 </body>
 </html>

--- a/frontend/src/pages/edit/edit-document-model.js
+++ b/frontend/src/pages/edit/edit-document-model.js
@@ -82,7 +82,7 @@ export default class EditDocumentModel {
   
   getParent(nodeId) {
     const node = this.getNode(nodeId);
-    return node.get('parent_id') ? this.getNode(node.get('parent_id')) : node;
+    return this.getNode(node.get('parent_id'));
   }
   
   getChildren(nodeId) {

--- a/frontend/src/pages/edit/edit-document-model.js
+++ b/frontend/src/pages/edit/edit-document-model.js
@@ -26,6 +26,12 @@ import {
   selectionReviver,
 } from './edit-selection-helpers';
 
+function reviver(key, value) {
+  return selectionReviver(key, value)
+    // ImmutableJS default behavior
+    || (isKeyed(value) ? value.toMap() : value.toList())
+}
+
 export default class EditDocumentModel {
   post;
   root;
@@ -33,18 +39,40 @@ export default class EditDocumentModel {
   infiniteLoopCount = 0;
   nodesByParentId = Map();
   
+  // this will trigger a shouldComponentUpdate -> true for re-rendering
+  // this function breaks references inside the nodesByParentId List for all ancestors of an updated node
+  setNodesByParentId(nodeId, updated) {
+    // replace the updated parent with new children
+    this.nodesByParentId = this.nodesByParentId.set(nodeId, updated);
+    if (nodeId === ROOT_NODE_PARENT_ID) {
+      return;
+    }
+    let currentId = nodeId;
+    // "touch" all ancestors to break references
+    while (currentId) {
+      const parentId = this.getParent(currentId).get('id') || ROOT_NODE_PARENT_ID;
+      const siblings = this.nodesByParentId.get(parentId);
+      const nodeIdx = siblings.findIndex(n => n.get('id') === currentId);
+      // TODO: find a better way to break the reference...
+      this.nodesByParentId = this.nodesByParentId.set(
+        parentId,
+        siblings.set(
+          nodeIdx,
+          Immutable.fromJS(this.getNode(currentId).toJS(), reviver),
+        )
+      );
+      currentId = this.getParent(currentId).get('id');
+    }
+  }
+  
   init(post, updateManager, jsonData = null) {
     this.post = Immutable.fromJS(post);
     // TODO: ideally this documentModel class doesn't have to know about the updateManager.
     // But, it's nice to make one call from the consumer (edit.jsx + helpers) that handles the documentModel
-    // and the updateManager behind the scenes, so that orchestration would have to move either out into edit.jsx or into another helper class
+    // and the updateManager behind the scenes.  That orchestration would have to move either out into edit.jsx or into another helper class
     this.updateManager = updateManager;
     if (jsonData) {
-      this.nodesByParentId = Immutable.fromJS(jsonData, (key, value) => {
-        return selectionReviver(key, value)
-          // ImmutableJS default behavior
-          || (isKeyed(value) ? value.toMap() : value.toList())
-      });
+      this.nodesByParentId = Immutable.fromJS(jsonData, reviver);
       this.root = this.getFirstChild(ROOT_NODE_PARENT_ID);
       this.rootId = this.root.get('id');
     } else {
@@ -90,7 +118,7 @@ export default class EditDocumentModel {
   }
   
   setChildren(nodeId, children) {
-    this.nodesByParentId = this.nodesByParentId.set(nodeId, children);
+    this.setNodesByParentId(nodeId, children);
     return this;
   }
   
@@ -231,7 +259,7 @@ export default class EditDocumentModel {
     const nodeIdx = siblings.findIndex(s => s.get('id') === nodeId);
     
     // update existing section
-    this.nodesByParentId = this.nodesByParentId.set(sectionId, siblings.slice(0, nodeIdx));
+    this.setNodesByParentId(sectionId, siblings.slice(0, nodeIdx));
     // if all existing nodes moved to the new section, create a new P
     if (this.nodesByParentId.get(sectionId).size === 0) {
       this.insert(sectionId, NODE_TYPE_P, 0);
@@ -239,7 +267,7 @@ export default class EditDocumentModel {
     this.updateNodesForParent(sectionId);
     // new section
     const newSectionId = this.insertSectionAfter(sectionId, NODE_TYPE_SECTION_CONTENT);
-    this.nodesByParentId = this.nodesByParentId.set(newSectionId, siblings.slice(nodeIdx));
+    this.setNodesByParentId(newSectionId, siblings.slice(nodeIdx));
     // if all existing nodes stayed in the existing section, create a new P
     if (this.nodesByParentId.get(newSectionId).size === 0) {
       this.insert(newSectionId, NODE_TYPE_P, 0);
@@ -313,9 +341,9 @@ export default class EditDocumentModel {
     // left or right could be empty because the selectedNode was already deleted
     const rightNodes = this.nodesByParentId.get(rightSectionId, List());
     const leftNodes = this.nodesByParentId.get(leftSectionId, List());
-    this.nodesByParentId = this.nodesByParentId.set(leftSectionId, leftNodes.concat(rightNodes));
+    this.setNodesByParentId(leftSectionId, leftNodes.concat(rightNodes));
     this.updateNodesForParent(leftSectionId);
-    this.nodesByParentId = this.nodesByParentId.set(rightSectionId, List());
+    this.setNodesByParentId(rightSectionId, List());
     this.delete(rightSectionId);
   }
   
@@ -340,7 +368,7 @@ export default class EditDocumentModel {
       meta: meta || Map(),
     });
     this.updateManager.stageNodeUpdate(newNode.get('id'));
-    this.nodesByParentId = this.nodesByParentId.set(parentId, siblings
+    this.setNodesByParentId(parentId, siblings
       .insert(newNode.get('position'), newNode)
     );
     // reindex children and persist changes
@@ -351,11 +379,11 @@ export default class EditDocumentModel {
   
   update(node) {
     const nodeId = node.get('id');
-    const parentId = this.getParent(nodeId).get('id');
+    const parentId = this.getParent(nodeId).get('id') || ROOT_NODE_PARENT_ID;
     const siblings = this.nodesByParentId.get(parentId);
     const nodeIdx = siblings.findIndex(n => n.get('id') === nodeId);
     this.updateManager.stageNodeUpdate(nodeId);
-    this.nodesByParentId = this.nodesByParentId.set(parentId, siblings.set(nodeIdx, node))
+    this.setNodesByParentId(parentId, siblings.set(nodeIdx, node))
     return nodeId
   }
   
@@ -377,7 +405,7 @@ export default class EditDocumentModel {
     const parentId = this.getParent(nodeId).get('id');
     const siblings = this.nodesByParentId.get(parentId);
     // filter this node out of its parent list
-    this.nodesByParentId = this.nodesByParentId.set(parentId, siblings
+    this.setNodesByParentId(parentId, siblings
       .filter(node => node.get('id') !== nodeId)
     );
     // delete this node's children list
@@ -392,9 +420,9 @@ export default class EditDocumentModel {
   updateNodesForParent(parentId) {
     // TODO: this is getting called 7 times when inserting a CodeSection
     //  it's clobbering deleted nodes with updates, it's a hot mess.
-    console.info('UPDATE NodesFor PARENT ', parentId);
+    console.info('UPDATE Nodes For PARENT ', parentId);
     const siblings = this.nodesByParentId.get(parentId, List());
-    this.nodesByParentId = this.nodesByParentId.set(
+    this.setNodesByParentId(
       parentId,
       siblings
       // reindex positions for remaining siblings

--- a/frontend/src/pages/edit/edit-document-model.js
+++ b/frontend/src/pages/edit/edit-document-model.js
@@ -88,12 +88,14 @@ export default class EditDocumentModel {
   
   getNode(nodeId) {
     this.infiniteLoopCount = 0;
+    // trying to find the parent of the root node makes for noisy logs
+    if ([null, "null"].includes(nodeId)) return Map();
     if (this.rootId === nodeId) return this.root;
     
     const queue = [this.rootId];
     while (queue.length) {
       if (this.infiniteLoopCount++ > 1000) {
-        throw new Error('getNode is Out of Control!!!');
+        throw new Error('getNode is Fuera de Control!!!');
       }
       const currentList = this.nodesByParentId.get(queue.shift(), List());
       const node = currentList.find(node => node.get('id') === nodeId);

--- a/frontend/src/pages/edit/edit.jsx
+++ b/frontend/src/pages/edit/edit.jsx
@@ -588,7 +588,7 @@ export default class EditPost extends React.Component {
     //console.debug('MouseUp Node: ', getCaretNode(), ' offset ', getCaretOffset())
     this.handleCaret(evt);
     this.manageInsertMenu();
-    this.manageFormatSelectionMenu();
+    this.manageFormatSelectionMenu(evt);
     // close edit section menus by default, this.sectionEdit() callback will fire after this to override
     this.sectionEditClose();
   }
@@ -939,6 +939,7 @@ export default class EditPost extends React.Component {
       formatSelectionNode: updatedNode,
       formatSelectionModel: updatedSelectionModel
     }, () => {
+      // TODO: selection highlight will be lost after rendering - create new range and add to window.selection
       if (updatedSelectionModel.get(SELECTION_ACTION_LINK) && this.inputRef) {
         this.inputRef.focus();
       }
@@ -998,7 +999,7 @@ export default class EditPost extends React.Component {
     const root = this.documentModel.nodesByParentId.get(ROOT_NODE_PARENT_ID, List()).get(0, Map());
 
     return (
-      <React.Fragment>
+      <main onMouseUp={this.handleMouseUp}>
         <Header>
           <HeaderContentContainer>
             <LogoLinkStyled to="/">✍️ filbert</LogoLinkStyled>
@@ -1029,12 +1030,11 @@ export default class EditPost extends React.Component {
                 successMessage={shouldShowPostSuccess}
                 errorMessage={shouldShowPostError}
               />)}
-              <div
+              <div id="filbert-edit-container"
                 contentEditable={true}
                 suppressContentEditableWarning={true}
                 onKeyDown={this.handleKeyDown}
                 onKeyUp={this.handleKeyUp}
-                onMouseUp={this.handleMouseUp}
                 onPaste={this.handlePaste}
               >
                 <ContentNode post={post} node={root} nodesByParentId={nodesByParentId} isEditing={this.sectionEdit} />
@@ -1074,7 +1074,7 @@ export default class EditPost extends React.Component {
           )}
         </Article>
         <Footer />
-      </React.Fragment>
+      </main>
     )
   }
 }

--- a/frontend/src/pages/footer.jsx
+++ b/frontend/src/pages/footer.jsx
@@ -12,7 +12,7 @@ export default () => (
   <Footer>
     🚚 1/4/2019
     <SocialLinksContainer>
-      <A href="https://github.com/bc-jasond/dubaniewicz-site"><GitHubStyled /></A>
+      <A href="https://github.com/bc-jasond/filbert"><GitHubStyled /></A>
       <A href="https://www.linkedin.com/in/jasondubaniewicz/"><LinkedInStyled /></A>
       <LogoLinkStyled to="/about"><InfoStyled /></LogoLinkStyled>
     </SocialLinksContainer>

--- a/frontend/src/pages/list-all-drafts.jsx
+++ b/frontend/src/pages/list-all-drafts.jsx
@@ -137,7 +137,7 @@ export default class AllPosts extends React.Component {
       <React.Fragment>
         <Header>
           <HeaderContentContainer>
-            <LogoLinkStyled to="/">✍ filbert</LogoLinkStyled>
+            <LogoLinkStyled to="/">✍️ filbert</LogoLinkStyled>
             <HeaderLinksContainer>
               {getSession()
                 ? (

--- a/frontend/src/pages/list-all-posts.jsx
+++ b/frontend/src/pages/list-all-posts.jsx
@@ -71,7 +71,7 @@ export default class AllPosts extends React.Component {
       <React.Fragment>
         <Header>
           <HeaderContentContainer>
-            <LogoLinkStyled to="/">✍ filbert</LogoLinkStyled>
+            <LogoLinkStyled to="/">✍️ filbert</LogoLinkStyled>
             <HeaderLinksContainer>
               {getSession()
                 ? (

--- a/frontend/src/pages/signin.jsx
+++ b/frontend/src/pages/signin.jsx
@@ -96,7 +96,7 @@ export default class SignIn extends React.Component {
     return (
       <Container>
         <SignInForm onSubmit={this.doLogin}>
-          <StyledLinkStyled to="/">✍ filbert</StyledLinkStyled>
+          <StyledLinkStyled to="/">✍️ filbert</StyledLinkStyled>
           <H1>Sign In</H1>
           <H3>Want an account? <StyledA onClick={() => alert('Coming soon!')}>Click here</StyledA></H3>
           <InputContainer>

--- a/frontend/src/pages/view-post.jsx
+++ b/frontend/src/pages/view-post.jsx
@@ -79,7 +79,7 @@ export default class ViewPost extends React.Component {
       <React.Fragment>
         <Header>
           <HeaderContentContainer>
-            <LogoLinkStyled to="/">✍ filbert</LogoLinkStyled>
+            <LogoLinkStyled to="/">✍️ filbert</LogoLinkStyled>
             <HeaderLinksContainer>
               {getSession()
                 ? (

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -5,12 +5,15 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = (env, argv) => {
   const isProduction = argv.mode === 'production';
+  const entry = ['@babel/polyfill'];
+  if (!isProduction) {
+    entry.push('react-hot-loader/patch');
+  }
+  entry.push('./src/index.jsx');
+  
   const config = {
     mode: isProduction ? 'production' : 'dev',
-    entry: [
-      '@babel/polyfill',
-      './src/index.jsx',
-    ],
+    entry,
     output: {
       path: path.resolve(__dirname, 'dist'),
       filename: '[name].[hash].js'

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4103,10 +4103,10 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.10.2:
+"react-dom@npm:@hot-loader/react-dom":
   version "16.10.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.10.2.tgz#4840bce5409176bc3a1f2bd8cb10b92db452fda6"
-  integrity sha512-kWGDcH3ItJK4+6Pl9DZB16BXYAZyrYQItU4OMy0jAkv5aNqc+mAKb4TpFtAteI6TJZu+9ZlNhaeNQSVQDHJzkw==
+  resolved "https://registry.yarnpkg.com/@hot-loader/react-dom/-/react-dom-16.10.2.tgz#91920442252acac6f343eef5df41aca333f7dcea"
+  integrity sha512-vbrSDuZMoE1TXiDNAVCSAcIS6UX55Fa9KF0MD0wQgOaOIPZs/C6CtEDUcnNFEwTQ5ciIULcp+96lQlSuANNagA==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"

--- a/mysql/filbert_create.sql
+++ b/mysql/filbert_create.sql
@@ -2,6 +2,17 @@
 CREATE DATABASE `filbert` /*!40100 DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_520_ci */;
 USE `filbert`;
 # tables
+CREATE TABLE `user` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `username` varchar(45) COLLATE utf8mb4_unicode_520_ci NOT NULL,
+  `email` varchar(150) COLLATE utf8mb4_unicode_520_ci NOT NULL,
+  `password` char(60) COLLATE utf8mb4_unicode_520_ci NOT NULL,
+  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `deleted` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `username_UNIQUE` (`username`) USING BTREE,
+  UNIQUE KEY `email_UNIQUE` (`email`) USING BTREE
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 CREATE TABLE `content_node` (
   `post_id` int(11) NOT NULL,
   `id` char(4) COLLATE utf8mb4_unicode_520_ci NOT NULL,
@@ -38,15 +49,4 @@ CREATE TABLE `post` (
   KEY `user_id_fk_idx` (`user_id`),
   CONSTRAINT `user_id_fk` FOREIGN KEY (`user_id`) REFERENCES `user` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
 ) ENGINE=InnoDB AUTO_INCREMENT=196 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
-CREATE TABLE `user` (
-  `id` int(11) NOT NULL AUTO_INCREMENT,
-  `username` varchar(45) COLLATE utf8mb4_unicode_520_ci NOT NULL,
-  `email` varchar(150) COLLATE utf8mb4_unicode_520_ci NOT NULL,
-  `password` char(60) COLLATE utf8mb4_unicode_520_ci NOT NULL,
-  `created` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `deleted` datetime DEFAULT NULL,
-  PRIMARY KEY (`id`),
-  UNIQUE KEY `username_UNIQUE` (`username`) USING BTREE,
-  UNIQUE KEY `email_UNIQUE` (`email`) USING BTREE
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci;
 


### PR DESCRIPTION
The impetus for this PR was to add Placeholder Text for when creating a new post, since the caret could be hard to see and there were no instructions.  This led to the discovery of bugs in the diff algorithm as well as new constraints: can't call `setState({nodesByParentId...` when syncing the DOM to the JS model of the content because the browser moves the caret.  BUT, more importantly, can't `setState` when syncing the DOM because the `contenteditable` HTML structure might have changed.  React doesn't like it when the rug is pulled out from under it and it Fatal Errors and whitescreens.  This was discovered when trying to `setState` after merging two `Selections` with the same formatting when a middle `Selection` is deleted (AKA, "heal" like formats).  SO, in order to continue to use React I'm going to try capturing ALL keystrokes and manually override by updating first the JS Model then calling `setState`.  I was hoping to be able to let `contenteditable` do magical things but, apparently I'm not allowed to have nice things.  Alternatively, I could go "uncontrolled" and just use vanilla JS inside the `contenteditable` div (or even just vanilla everything on the edit page???).  Maybe I'll try both.

Also uncovered were some issues in `Edit->render()` which led to adding a "update and touch all ancestors" algorithm to mimic ImmutableJS persistent "copy" behavior.  Since the nodes are stored in a flattened list of parentId->[children], each parent needs to be found in a list and then "touched" in order to break the reference and make `shouldComponentUpdate()` return true.

- `setNodesByParentId` API - "touch" all ancestors of an updated node to break references
- add react-dom entry
- rename stuff from dubaniewicz -> filbert
- fix htmlentity replacement for &nbsp; (code 160) to " " (code 32)
- move the `onMouseUp` handler from the `contenteditable` div to a new `<main>` wrapper tag for better handling of the format selection menu