### PR TITLE
Intercept all keystrokes - first fully working version!

### DIFF
--- a/frontend/src/common/content-node.component.jsx
+++ b/frontend/src/common/content-node.component.jsx
@@ -54,7 +54,10 @@ import {
   cleanTextOrZeroLengthPlaceholder,
   imageUrlIsId,
 } from './utils';
-import { getSelectionKey } from '../pages/edit/edit-selection-helpers';
+import {
+  getContentForSelection,
+  getSelectionKey,
+} from '../pages/edit/edit-selection-helpers';
 
 const StyledDiv = styled.div``;
 
@@ -261,19 +264,10 @@ export default class ContentNode extends React.Component {
         const meta = node.get('meta', Map());
         const selections = meta
           .get('selections', List([Map()]));
-        const getContentForSelection = (selection) => {
-          let content = node.get('content');
-          if (content === undefined || content === null) {
-            content = '';
-          }
-          const startOffset = selection.get('start');
-          const endOffset = selection.get('end');
-          return cleanTextOrZeroLengthPlaceholder(content.substring(startOffset, endOffset));
-        };
         let children = [];
         selections.forEach((selection) => {
           const key = getSelectionKey(selection);
-          let selectionJsx = getContentForSelection(selection);
+          let selectionJsx = getContentForSelection(node, selection);
           if (selection.get(SELECTION_ACTION_STRIKETHROUGH)) {
             selectionJsx = (<StrikeText key={key}>{selectionJsx}</StrikeText>)
           }

--- a/frontend/src/common/css.js
+++ b/frontend/src/common/css.js
@@ -7,3 +7,5 @@ export const blue = '#79bbd5';
 export const darkBlue = '#52a8c9';
 export const error = '#cc0000';
 export const success = '#5CB85C';
+
+export const lineHeight = 26;

--- a/frontend/src/common/dom.js
+++ b/frontend/src/common/dom.js
@@ -1,6 +1,8 @@
  import {
   NODE_TYPE_SECTION_CONTENT,
   NODE_TYPE_SECTION_H1,
+  NODE_TYPE_P,
+  NODE_TYPE_LI,
   DOM_TEXT_NODE_TYPE_ID,
   KEYCODE_TAB,
   KEYCODE_SHIFT_RIGHT,
@@ -30,8 +32,9 @@
   KEYCODE_F10,
   KEYCODE_F11,
   KEYCODE_F12,
-  KEYCODE_PRINT_SCREEN, NODE_TYPE_P, NODE_TYPE_LI,
+  KEYCODE_PRINT_SCREEN,
 } from './constants';
+ import {cleanText} from "./utils";
 
 let infiniteLoopCount = 0;
 
@@ -71,7 +74,11 @@ export function setCaret(nodeId, offset = -1, shouldFindLastNode = false) {
   if (textNode) {
     console.info('setCaret textNode ', textNode, ' offset ', offset);
     // set caret to end of text content
-    range.setStart(textNode, offset === -1 ? textNode.textContent.length : offset);
+    let caretOffset = offset;
+    if (offset === -1 || offset > textNode.textContent.length) {
+      caretOffset = textNode.textContent.length;
+    }
+    range.setStart(textNode, caretOffset);
     sel.addRange(range);
   } else {
     console.warn(`setCaret - couldn't find a text node inside of `, nodeId);
@@ -117,6 +124,10 @@ export function getOffsetInParentContent() {
   for (let i = 0; i < rangeIdx; i++) {
     // for each child of the paragraph that precedes our current range - add the length of it's content to the offset
     offset += paragraph.childNodes[i].textContent.length;
+  }
+  // special case for an empty paragraph with a ZERO_LENGTH_PLACEHOLDER
+  if (rangeStartOffset === 1 && cleanText(paragraph.textContent).length === 0) {
+    return [0, 0];
   }
   // now we'll have the correct positioning of the selected text inside the paragraph (the node that holds the 'content' saved to the DB) text as a whole no matter what formatting tags have been applied
   return [rangeStartOffset + offset, rangeEndOffset + offset];

--- a/frontend/src/common/layout-styled-components.jsx
+++ b/frontend/src/common/layout-styled-components.jsx
@@ -77,12 +77,12 @@ export const HeaderSpacer = styled.div`
 export const Article = styled.article`
   width: 100%;
   min-height: 80vh;
-  padding: 0 20px 80px;
+  padding: 40px 80px;
   margin: 0 auto;
   box-sizing: border-box;
   position: relative;
   @media (max-width: 800px) {
-    padding: 0 20px 80px 20px;
+    padding: 40px 20px;
   }
 `;
 export const Footer = styled.footer`

--- a/frontend/src/common/shared-styled-components.jsx
+++ b/frontend/src/common/shared-styled-components.jsx
@@ -202,6 +202,7 @@ export const ImagePlaceholderFill = styled.div`
 `;
 export const Img = styled.img`
   position: absolute;
+  box-sizing: border-box;
   top: 0;
   left: 0;
   width: 100%;

--- a/frontend/src/common/utils.js
+++ b/frontend/src/common/utils.js
@@ -38,8 +38,6 @@ export function cleanText(text) {
   const re = new RegExp(ZERO_LENGTH_CHAR);
   return text
     .replace(re, '')
-
-    //
 }
 
 export function normalizeHtmlEntities(text) {
@@ -65,13 +63,10 @@ export function getDiffStartAndLength(oldStr, newStr) {
     if (newCurrent.length === 0) {
       // chars were deleted from the end
       // offset the loop counter to account for the change in direction (right to left for a 'delete')
-      return [i + diffLength, -diffLength];
+      return [i, -diffLength];
     }
     if (oldCurrent !== newCurrent) {
-      if (doesAddCharacters) {
-        return [i, diffLength];
-      }
-      return [i + diffLength, -diffLength];
+      return [i, doesAddCharacters ? diffLength : -diffLength];
     }
   }
   // strings are the same!

--- a/frontend/src/common/utils.js
+++ b/frontend/src/common/utils.js
@@ -40,7 +40,20 @@ export function cleanText(text) {
     .replace(re, '')
 }
 
-export function normalizeHtmlEntities(text) {
+export function getCharFromEvent(evt, node, offset) {
+  if (evt && typeof evt.keyCode !== undefined) {
+    // TODO: replace only necessary spaces with &nbsp;
+    if (evt.keyCode === 32) {
+      return String.fromCharCode(160);
+    }
+    return evt.key;
+  } else {
+    // TODO: handle emoji keyboard insert
+    return evt.nativeEvent.data;
+  }
+}
+
+function normalizeHtmlEntities(text) {
   // TODO: what other htmlentities need to be normalized here?
   // for pesky char code 160 ( &nbsp; )
   // contenteditable automatically converts between " " 32 and "&nbsp;" 160 for placeholder spaces at the end of tags or sequential spaces

--- a/frontend/src/pages/edit/edit-publish-post-form.jsx
+++ b/frontend/src/pages/edit/edit-publish-post-form.jsx
@@ -25,7 +25,6 @@ const publishPostFields = [
     fieldName: 'canonical',
     StyledComponent: Input,
     disabled: post => {
-      console.log(post.get('published'));
       return post.get('published')
     },
   }, {
@@ -58,6 +57,7 @@ export default ({
                   close,
                   successMessage,
                   errorMessage,
+                  forwardRef,
                 }) => (
   <PublishPostFormContainer>
     <PublishPostForm>
@@ -72,7 +72,9 @@ export default ({
                                onChange={(e) => {
                                  updatePost(fieldName, e.target.value)
                                }}
-                               error={false /*TODO*/}/>
+                               error={false /*TODO*/}
+                               ref={idx === 0 ? forwardRef : () => {}}
+              />
             </InputContainer>
           )
         }

--- a/frontend/src/pages/edit/edit-publish-post-form.jsx
+++ b/frontend/src/pages/edit/edit-publish-post-form.jsx
@@ -14,7 +14,7 @@ import {
   MessageContainer,
 } from '../../common/shared-styled-components';
 
-import { formatPostDate } from '../../common/utils';
+import {formatPostDate} from '../../common/utils';
 
 const publishPostFields = [
   {
@@ -24,7 +24,10 @@ const publishPostFields = [
   }, {
     fieldName: 'canonical',
     StyledComponent: Input,
-    disabled: post => { console.log(post.get('published')); return post.get('published') },
+    disabled: post => {
+      console.log(post.get('published'));
+      return post.get('published')
+    },
   }, {
     fieldName: 'abstract',
     StyledComponent: TextArea,
@@ -34,12 +37,12 @@ const publishPostFields = [
 
 const PublishPostFormContainer = styled.div`
   position: absolute;
-  top: 0;
+  top: 65px;
   left: 0;
   width: 100%;
   z-index: 10;
   background-color: white;
-`
+`;
 const PublishPostForm = styled.div`
   position: relative;
   width: 50%;
@@ -59,17 +62,21 @@ export default ({
   <PublishPostFormContainer>
     <PublishPostForm>
       <H1>{`${post.get('published') ? 'Post' : 'Draft'}: Details & Publish`}</H1>
-      {publishPostFields.map(({ fieldName, StyledComponent, disabled }, idx) => (
-        <InputContainer key={idx}>
-          <Label htmlFor={fieldName} error={false /*TODO*/}>{fieldName}</Label>
-          <StyledComponent name={fieldName} type="text" value={post.get(fieldName, '')}
-                           disabled={disabled(post) && 'disabled'}
-                           onChange={(e) => {
-                             updatePost(fieldName, e.target.value)
-                           }}
-                           error={false /*TODO*/} />
-        </InputContainer>
-      ))}
+      {publishPostFields.map(({fieldName, StyledComponent, disabled}, idx) => {
+          const fieldValue = post.get(fieldName) || ''; // null doesn't fail the notSetValue check in ImmutableJS
+          return (
+            <InputContainer key={idx}>
+              <Label htmlFor={fieldName} error={false /*TODO*/}>{fieldName}</Label>
+              <StyledComponent name={fieldName} type="text" value={fieldValue}
+                               disabled={disabled(post) && 'disabled'}
+                               onChange={(e) => {
+                                 updatePost(fieldName, e.target.value)
+                               }}
+                               error={false /*TODO*/}/>
+            </InputContainer>
+          )
+        }
+      )}
       <MessageContainer>
         {errorMessage && (<ErrorMessage>Error 🤷‍</ErrorMessage>)}
         {successMessage && (<SuccessMessage>Saved 👍</SuccessMessage>)}

--- a/frontend/src/pages/edit/edit-selection-helpers.js
+++ b/frontend/src/pages/edit/edit-selection-helpers.js
@@ -34,7 +34,7 @@ export function formatSelections(s) {
   if (!List.isList(s)) {
     return;
   }
-  return s.reduce((acc, v) => `${acc} | start: ${v.get(SELECTION_START)}, end: ${v.get(SELECTION_END)}`, '');
+  return `${s.reduce((acc, v) => `${acc} | start: ${v.get(SELECTION_START)}, end: ${v.get(SELECTION_END)}`, '')} |`;
 }
 
 /**
@@ -237,7 +237,7 @@ export function adjustSelectionOffsetsAndCleanup(nodeModel, start = 0, count = 0
 
   let newModel = nodeModel;
   if (!selections.equals(newSelections)) {
-    console.log('ADJUST         ', formatSelections(newSelections), 'start: ', start, ' count: ', count, ' length: ', contentLength);
+    console.log('ADJUST         ', formatSelections(newSelections), ' -- offset: ', start, ' count: ', count, ' content length: ', contentLength);
     newModel = setSelections(nodeModel, newSelections);
   }
   newModel = fillEnds(newModel);

--- a/frontend/src/pages/edit/edit-selection-helpers.js
+++ b/frontend/src/pages/edit/edit-selection-helpers.js
@@ -1,4 +1,4 @@
-import { List, Record } from 'immutable';
+import {List, Record} from 'immutable';
 
 import {
   SELECTION_ACTION_BOLD,
@@ -7,12 +7,15 @@ import {
   SELECTION_ACTION_STRIKETHROUGH,
   SELECTION_ACTION_SITEINFO,
   SELECTION_ACTION_LINK,
-  SELECTION_LINK_URL, SELECTION_START, SELECTION_END,
+  SELECTION_LINK_URL,
+  SELECTION_START,
+  SELECTION_END,
 } from '../../common/constants';
+import {cleanTextOrZeroLengthPlaceholder} from "../../common/utils";
 
 export const Selection = Record({
-  start: 0,
-  end: -1,
+  [SELECTION_START]: 0,
+  [SELECTION_END]: -1,
   [SELECTION_ACTION_BOLD]: false,
   [SELECTION_ACTION_ITALIC]: false,
   [SELECTION_ACTION_CODE]: false,
@@ -23,18 +26,27 @@ export const Selection = Record({
 });
 
 export function selectionReviver(key, value) {
-  if (value.has('start') && value.has('end')) {
+  if (value.has(SELECTION_START) && value.has(SELECTION_END)) {
     return new Selection(value)
   }
 }
-
-function formatSelections(s) {
-  return s.reduce((acc, v) => `${acc} | start: ${v.get('start')}, end: ${v.get('end')}`, '');
+export function formatSelections(s) {
+  if (!List.isList(s)) {
+    return;
+  }
+  return s.reduce((acc, v) => `${acc} | start: ${v.get(SELECTION_START)}, end: ${v.get(SELECTION_END)}`, '');
 }
 
 /**
  * PRIVATE HELPERS
  */
+function getSelections(nodeModel) {
+  return nodeModel.getIn(['meta', 'selections'], List());
+}
+function setSelections(nodeModel, value) {
+  return nodeModel.setIn(['meta', 'selections'], value);
+}
+
 function selectionsHaveDifferentFormats(left, right) {
   return [
     SELECTION_ACTION_BOLD,
@@ -43,7 +55,7 @@ function selectionsHaveDifferentFormats(left, right) {
     SELECTION_ACTION_STRIKETHROUGH,
     SELECTION_ACTION_SITEINFO,
     SELECTION_ACTION_LINK,
-    'linkUrl',
+    SELECTION_LINK_URL,
   ].reduce((acc, key) => acc || left.get(key) !== right.get(key), false);
 }
 
@@ -54,19 +66,19 @@ function selectionsHaveDifferentFormats(left, right) {
  * @returns {Selection}
  */
 function applyFormatsOfOverlappingSelections(nodeModel, newSelection) {
-  const selections = nodeModel.getIn(['meta', 'selections'], List());
+  const selections = getSelections(nodeModel);
   return selections
     .filter(s =>
       // newSelection overlaps s to the right
-      (newSelection.get('start') >= s.get('start') && newSelection.get('start') <= s.get('end'))
+      (newSelection.get(SELECTION_START) >= s.get(SELECTION_START) && newSelection.get(SELECTION_START) <= s.get(SELECTION_END))
       // newSelection overlaps s to the left
-      || (newSelection.get('end') >= s.get('start') && newSelection.get('end') <= s.get('end'))
+      || (newSelection.get(SELECTION_END) >= s.get(SELECTION_START) && newSelection.get(SELECTION_END) <= s.get(SELECTION_END))
       // newSelection envelops s completely
-      || (newSelection.get('start') < s.get('start') && newSelection.get('end') > s.get('end')))
+      || (newSelection.get(SELECTION_START) < s.get(SELECTION_START) && newSelection.get(SELECTION_END) > s.get(SELECTION_END)))
     .reduce((acc, selection) => acc.mergeWith(
       (oldVal, newVal, key) => {
-        // don't blow away non-formatting related values like 'start' or 'end'
-        if (!key.includes('selection')) {
+        // don't blow away non-formatting related values like SELECTION_START or SELECTION_END
+        if ([SELECTION_START, SELECTION_END, SELECTION_LINK_URL].includes(key)) {
           return oldVal
         }
         return newVal || oldVal
@@ -77,27 +89,27 @@ function applyFormatsOfOverlappingSelections(nodeModel, newSelection) {
 function mergeOverlappingSelections(nodeModel, newSelection) {
   let didPushNewSelection = false;
   let newSelections = List();
-  const selections = nodeModel.getIn(['meta', 'selections'], List());
+  const selections = getSelections(nodeModel);
   if (selections.size === 0) {
     newSelections = newSelections.push(newSelection);
   }
   for (let i = 0; i < selections.size; i++) {
     const current = selections.get(i);
     // current selection IS newSelection
-    if (current.get('start') === newSelection.get('start') && current.get('end') === newSelection.get('end')) {
+    if (current.get(SELECTION_START) === newSelection.get(SELECTION_START) && current.get(SELECTION_END) === newSelection.get(SELECTION_END)) {
       newSelections = newSelections.push(newSelection);
       didPushNewSelection = true;
       continue;
     }
     // current selection doesn't overlap - push it
-    if (current.get('end') <= newSelection.get('start') || current.get('start') >= newSelection.get('end')) {
+    if (current.get(SELECTION_END) <= newSelection.get(SELECTION_START) || current.get(SELECTION_START) >= newSelection.get(SELECTION_END)) {
       newSelections = newSelections.push(current);
       continue;
     }
     // current selection overlaps to the left
-    if (current.get('start') < newSelection.get('start')) {
+    if (current.get(SELECTION_START) < newSelection.get(SELECTION_START)) {
       newSelections = newSelections
-        .push(current.set('end', newSelection.get('start')))
+        .push(current.set(SELECTION_END, newSelection.get(SELECTION_START)))
     }
     // push new selection
     if (!didPushNewSelection) {
@@ -105,16 +117,16 @@ function mergeOverlappingSelections(nodeModel, newSelection) {
       didPushNewSelection = true;
     }
     // current selection overlaps to the right
-    if (current.get('end') > newSelection.get('end')) {
-      newSelections = newSelections.push(current.set('start', newSelection.get('end')));
+    if (current.get(SELECTION_END) > newSelection.get(SELECTION_END)) {
+      newSelections = newSelections.push(current.set(SELECTION_START, newSelection.get(SELECTION_END)));
     }
     // current selection falls completely within newSelection - skip since it's styles have already been merged with `applyFormatsOfOverlappingSelections` (noop)
-    // if (current.get('start') >= newSelection.get('start') && current.get('end') <= newSelection.get('end')) {
+    // if (current.get(SELECTION_START) >= newSelection.get(SELECTION_START) && current.get(SELECTION_END) <= newSelection.get(SELECTION_END)) {
     //   continue;
     // }
   }
-  
-  return nodeModel.setIn(['meta', 'selections'], newSelections);
+
+  return setSelections(nodeModel, newSelections);
 }
 
 /**
@@ -122,24 +134,24 @@ function mergeOverlappingSelections(nodeModel, newSelection) {
  * @param selections
  */
 function fillEnds(nodeModel) {
-  const selections = nodeModel.getIn(['meta', 'selections'], List());
+  const selections = getSelections(nodeModel);
   const contentLength = nodeModel.get('content', '').length;
   let newSelections = selections;
   let minStart = contentLength;
   let maxEnd = 0;
   selections.forEach(s => {
-    minStart = Math.min(minStart, s.get('start'));
-    maxEnd = Math.max(maxEnd, s.get('end'));
+    minStart = Math.min(minStart, s.get(SELECTION_START));
+    maxEnd = Math.max(maxEnd, s.get(SELECTION_END));
   });
   if (minStart > 0) {
-    newSelections = newSelections.insert(0, Selection({ 'start': 0, 'end': minStart }));
+    newSelections = newSelections.insert(0, Selection({[SELECTION_START]: 0, [SELECTION_END]: minStart}));
   }
   if (maxEnd < contentLength) {
-    newSelections = newSelections.push(Selection({ 'start': maxEnd, 'end': contentLength }))
+    newSelections = newSelections.push(Selection({[SELECTION_START]: maxEnd, [SELECTION_END]: contentLength}))
   }
   if (!selections.equals(newSelections)) {
     console.log('FILL ENDS      ', formatSelections(newSelections));
-    return nodeModel.setIn(['meta', 'selections'], newSelections);
+    return setSelections(nodeModel, newSelections);
   }
   return nodeModel;
 }
@@ -158,7 +170,7 @@ function fillEnds(nodeModel) {
  */
 function mergeAdjacentSelectionsWithSameFormats(nodeModel) {
   let newSelections = List();
-  const selections = nodeModel.getIn(['meta', 'selections'], List());
+  const selections = getSelections(nodeModel);
   if (selections.size === 0) {
     return nodeModel;
   }
@@ -170,18 +182,17 @@ function mergeAdjacentSelectionsWithSameFormats(nodeModel) {
       current = next;
     } else {
       // if the formats are the same, just extend the current selection
-      current = current.set('end', next.get('end'));
+      current = current.set(SELECTION_END, next.get(SELECTION_END));
     }
   }
   newSelections = newSelections.push(current);
   // SUPER PERFORMANCE OPTIMIZATION: if there's only one Selection and it's empty - clear it out
-  // TODO: have this function take the content node model itself so it can clean 'meta' if it has an empty 'selections' list
   if (newSelections.size === 1 && !selectionsHaveDifferentFormats(newSelections.get(0), Selection())) {
     newSelections = List();
   }
   if (!selections.equals(newSelections)) {
     console.log('MERGE ADJACENT ', formatSelections(newSelections));
-    return nodeModel.setIn(['meta', 'selections'], newSelections);
+    return setSelections(nodeModel, newSelections);
   }
   return nodeModel;
 }
@@ -200,7 +211,7 @@ function mergeAdjacentSelectionsWithSameFormats(nodeModel) {
  *
  */
 export function adjustSelectionOffsetsAndCleanup(nodeModel, start = 0, count = 0) {
-  const selections = nodeModel.getIn(['meta', 'selections'], List());
+  const selections = getSelections(nodeModel);
   if (selections.size === 0) {
     return nodeModel.deleteIn(['meta', 'selections']);
   }
@@ -209,44 +220,44 @@ export function adjustSelectionOffsetsAndCleanup(nodeModel, start = 0, count = 0
   const contentLength = nodeModel.get('content', '').length;
   for (let i = 0; i < selections.size; i++) {
     let current = selections.get(i);
-    if (current.get('start') >= start) {
-      current = current.set('start', current.get('start') + count)
+    if (current.get(SELECTION_START) >= start) {
+      current = current.set(SELECTION_START, current.get(SELECTION_START) + count)
     }
-    if (current.get('end') >= start) {
-      current = current.set('end', current.get('end') + count)
+    if (current.get(SELECTION_END) >= start) {
+      current = current.set(SELECTION_END, current.get(SELECTION_END) + count)
     }
     // for deleting characters: don't push empty selections
-    if (current.get('end') > current.get('start')) {
+    if (current.get(SELECTION_END) > current.get(SELECTION_START)) {
       newSelections = newSelections.push(current);
     }
   }
-  
+
   let newModel = nodeModel;
   if (!selections.equals(newSelections)) {
     console.log('ADJUST         ', formatSelections(newSelections), 'start: ', start, ' count: ', count, ' length: ', contentLength);
-    newModel = nodeModel.setIn(['meta', 'selections'], newSelections);
+    newModel = setSelections(nodeModel, newSelections);
   }
   newModel = mergeAdjacentSelectionsWithSameFormats(newModel);
   return fillEnds(newModel);
 }
 
 /**
- * NOTE: returns Selection
+ * NOTE: returns Selection for the format selection menu
  * @param nodeModel
  * @param start
  * @param end
  * @returns {Selection}
  */
 export function getSelection(nodeModel, start, end) {
-  const selections = nodeModel.getIn(['meta', 'selections'], List());
-  let selection = selections.find(s => s.get('start') === start && s.get('end') === end, null, Selection());
+  const selections = getSelections(nodeModel);
+  let selection = selections.find(s => s.get(SELECTION_START) === start && s.get(SELECTION_END) === end, null, Selection());
   // selection already exists?
-  if (selection.get('end') === end) {
+  if (selection.get(SELECTION_END) === end) {
     return selection;
   }
   selection = selection
-    .set('start', start)
-    .set('end', end);
+    .set(SELECTION_START, start)
+    .set(SELECTION_END, end);
   return applyFormatsOfOverlappingSelections(nodeModel, selection);
 }
 
@@ -256,6 +267,7 @@ export function getSelection(nodeModel, start, end) {
  * 1) create one selection the total length of textContent
  *    OR two selections starting at position 0 or ending at textContent.length - 1
  *    OR 3 selections, an empty one in beginning, one in the middle and another empty one at the end
+ *
  * An unformatted paragraph can have no selections but, if it has 1 or more, it can't have any gaps
  *
  * 1) add attributes from overlapping selections if they have formats (might be empty)
@@ -281,63 +293,61 @@ export function upsertSelection(nodeModel, newSelection) {
 export function splitSelectionsAtCaretOffset(leftNodeModel, rightNodeModel, caretOffset) {
   let left = List();
   let right = List();
-  const selections = leftNodeModel.getIn(['meta', 'selections'], List());
+  const selections = getSelections(leftNodeModel);
   for (let i = 0; i < selections.size; i++) {
     const current = selections.get(i);
-    if (current.get('end') <= caretOffset) {
+    if (current.get(SELECTION_END) <= caretOffset) {
       left = left.push(current);
       continue;
     }
-    if (current.get('start') >= caretOffset) {
+    if (current.get(SELECTION_START) >= caretOffset) {
       right = right.push(current
-        .set('start', current.get('start') - caretOffset)
-        .set('end', current.get('end') - caretOffset)
+        .set(SELECTION_START, current.get(SELECTION_START) - caretOffset)
+        .set(SELECTION_END, current.get(SELECTION_END) - caretOffset)
       );
       continue;
     }
     // caretOffset must be in the middle of a selection, split
     left = left.push(current
-      .set('end', caretOffset));
+      .set(SELECTION_END, caretOffset));
     right = right.push(current
-      .set('start', 0)
-      .set('end', current.get('end') - caretOffset)
+      .set(SELECTION_START, 0)
+      .set(SELECTION_END, current.get(SELECTION_END) - caretOffset)
     );
   }
-  leftNodeModel = leftNodeModel.setIn(['meta', 'selections'], left);
+  leftNodeModel = setSelections(leftNodeModel, left);
   leftNodeModel = adjustSelectionOffsetsAndCleanup(leftNodeModel);
-  rightNodeModel = rightNodeModel.setIn(['meta', 'selections'], right);
+  rightNodeModel = setSelections(rightNodeModel, right);
   rightNodeModel = adjustSelectionOffsetsAndCleanup(rightNodeModel);
   return [leftNodeModel, rightNodeModel];
 }
 
 export function concatSelections(leftModel, rightModel) {
-  const left = leftModel.getIn(['meta', 'selections'], List());
-  let right = rightModel.getIn(['meta', 'selections'], List());
+  const left = getSelections(leftModel);
+  let right = getSelections(rightModel);
   let newSelections = left.slice();
-  const leftOffset = left.last(Selection()).get('end');
-  // TODO: use if the formats for the last left and first right selections are the same, merge them
-  if (left.size > 0 && right.size > 0 && !selectionsHaveDifferentFormats(left.last(), right.first())) {
-    newSelections = newSelections
-      .pop()
-      .push(left
-        .last()
-        .set('end', right
-          .first()
-          .get('end') + leftOffset
-        )
-      );
-    right = right.shift();
-  }
+  const leftOffset = left.last(Selection()).get(SELECTION_END);
   // add all right selections with left offsets
+  // NOTE: if left.last() and right.first() have the same formats, they'll be merged in mergeAdjacent
   for (let i = 0; i < right.size; i++) {
     const current = right.get(i);
     newSelections = newSelections.push(current
-      .set('start', current.get('start') + leftOffset)
-      .set('end', current.get('end') + leftOffset)
+      .set(SELECTION_START, current.get(SELECTION_START) + leftOffset)
+      .set(SELECTION_END, current.get(SELECTION_END) + leftOffset)
     )
   }
-  leftModel = leftModel.setIn(['meta', 'selections'], newSelections);
+  leftModel = setSelections(leftModel, newSelections);
   return adjustSelectionOffsetsAndCleanup(leftModel);
+}
+
+export function getContentForSelection(node, selection) {
+  let content = node.get('content');
+  if (content === undefined || content === null) {
+    content = '';
+  }
+  const startOffset = selection.get(SELECTION_START);
+  const endOffset = selection.get(SELECTION_END);
+  return cleanTextOrZeroLengthPlaceholder(content.substring(startOffset, endOffset));
 }
 
 export function getSelectionKey(s) {

--- a/frontend/src/pages/edit/edit.jsx
+++ b/frontend/src/pages/edit/edit.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import styled from 'styled-components';
 import { List, Map, fromJS } from 'immutable';
 import { Redirect } from 'react-router-dom';
 
@@ -123,6 +124,12 @@ import PublishPostForm from './edit-publish-post-form';
 
 import Page404 from '../404';
 
+const ArticleStyled = styled(Article)`
+  @media (max-width: 800px) {
+    padding: 40px 80px;
+  }
+`;
+
 export default class EditPost extends React.Component {
   constructor(props) {
     super(props);
@@ -153,6 +160,7 @@ export default class EditPost extends React.Component {
   async componentDidMount() {
     console.log("EDIT - didMount")
     try {
+      window.addEventListener('resize', this.manageInsertMenu.bind(this));
       if (this.props.match.params.id === NEW_POST_URL_ID) {
         return this.newPost();
       }
@@ -1035,7 +1043,7 @@ export default class EditPost extends React.Component {
             </HeaderContentContainer>
           </Header>
           <HeaderSpacer />
-          <Article>
+          <ArticleStyled>
             {root.get('id') && (
               <div id="filbert-edit-container"
                 contentEditable={true}
@@ -1047,7 +1055,7 @@ export default class EditPost extends React.Component {
                 <ContentNode post={post} node={root} nodesByParentId={nodesByParentId} isEditing={this.sectionEdit} />
               </div>
             )}
-          </Article>
+          </ArticleStyled>
           <Footer />
         </main>
         {shouldShowPublishPostMenu && (<PublishPostForm

--- a/frontend/src/pages/edit/edit.jsx
+++ b/frontend/src/pages/edit/edit.jsx
@@ -561,10 +561,17 @@ export default class EditPost extends React.Component {
       return;
     }
     const domNode = getCaretNode();
-    if (domNode && (domNode.tagName === 'PRE'
+    if (!domNode) return;
+    if (domNode.tagName === 'PRE'
       // when clicking on a section, the caret will be on an input in the edit image or quote menu, ignore
-      || domNode.dataset.isMenu === 'true' /* TODO: why string? */)) {
+      || domNode.dataset.isMenu === 'true' /* TODO: why string? */) {
       // TODO
+      return;
+    }
+    // TODO: clicking on the <article> tag comes back as the header-spacer???
+    //  if we're clicking on the document container, focus the end of the last node
+    if (domNode.id === 'header-spacer') {
+      setCaret(this.documentModel.rootId, -1, true);
       return;
     }
     const selectedNodeId = getCaretNodeId(domNode);
@@ -1042,7 +1049,7 @@ export default class EditPost extends React.Component {
               </HeaderLinksContainer>
             </HeaderContentContainer>
           </Header>
-          <HeaderSpacer />
+          <HeaderSpacer id="header-spacer" />
           <ArticleStyled>
             {root.get('id') && (
               <div id="filbert-edit-container"

--- a/frontend/src/pages/edit/edit.jsx
+++ b/frontend/src/pages/edit/edit.jsx
@@ -1037,30 +1037,28 @@ export default class EditPost extends React.Component {
           <HeaderSpacer />
           <Article>
             {root.get('id') && (
-              <React.Fragment>
-                {shouldShowPublishPostMenu && (<PublishPostForm
-                  post={post}
-                  updatePost={this.updatePost}
-                  publishPost={this.publishPost}
-                  savePost={this.savePost}
-                  close={this.togglePostMenu}
-                  successMessage={shouldShowPostSuccess}
-                  errorMessage={shouldShowPostError}
-                />)}
-                <div id="filbert-edit-container"
-                  contentEditable={true}
-                  suppressContentEditableWarning={true}
-                  onKeyDown={this.handleKeyDown}
-                  onInput={this.handleKeyUp}
-                  onPaste={this.handlePaste}
-                >
-                  <ContentNode post={post} node={root} nodesByParentId={nodesByParentId} isEditing={this.sectionEdit} />
-                </div>
-              </React.Fragment>
+              <div id="filbert-edit-container"
+                contentEditable={true}
+                suppressContentEditableWarning={true}
+                onKeyDown={this.handleKeyDown}
+                onInput={this.handleKeyUp}
+                onPaste={this.handlePaste}
+              >
+                <ContentNode post={post} node={root} nodesByParentId={nodesByParentId} isEditing={this.sectionEdit} />
+              </div>
             )}
           </Article>
           <Footer />
         </main>
+        {shouldShowPublishPostMenu && (<PublishPostForm
+            post={post}
+            updatePost={this.updatePost}
+            publishPost={this.publishPost}
+            savePost={this.savePost}
+            close={this.togglePostMenu}
+            successMessage={shouldShowPostSuccess}
+            errorMessage={shouldShowPostError}
+        />)}
         {shouldShowInsertMenu && (<InsertSectionMenu
             insertMenuTopOffset={insertMenuTopOffset}
             insertMenuLeftOffset={insertMenuLeftOffset}

--- a/frontend/src/pages/edit/edit.jsx
+++ b/frontend/src/pages/edit/edit.jsx
@@ -7,7 +7,8 @@ import {
   apiDelete,
   apiGet,
   apiPatch,
-  apiPost, uploadImage,
+  apiPost,
+  uploadImage,
 } from '../../common/fetch';
 import {
   Article,
@@ -29,16 +30,15 @@ import {
   confirmPromise,
   cleanText,
   cleanTextOrZeroLengthPlaceholder,
-  getDiffStartAndLength,
   getCanonicalFromTitle,
   imageUrlIsId,
+  getCharFromEvent,
 } from '../../common/utils';
 import {
   getRange,
   getCaretNode,
   getCaretNodeId,
   getCaretNodeType,
-  getCaretOffset,
   getFirstHeadingContent,
   setCaret,
   getOffsetInParentContent,
@@ -73,8 +73,9 @@ import {
   SELECTION_ACTION_SITEINFO,
   SELECTION_ACTION_LINK,
   SELECTION_LINK_URL,
-  POST_ACTION_REDIRECT_TIMEOUT, ZERO_LENGTH_CHAR,
+  POST_ACTION_REDIRECT_TIMEOUT,
 } from '../../common/constants';
+import { lineHeight } from "../../common/css";
 
 import ContentNode from '../../common/content-node.component';
 import EditDocumentModel from './edit-document-model';
@@ -97,6 +98,7 @@ import {
 import {
   handleBackspaceParagraph,
   handleEnterParagraph,
+  handlePasteParagraph,
   paragraphToTitle,
   titleToParagraph,
 } from './handle-paragraph';
@@ -111,7 +113,6 @@ import {
 import {
   Selection,
   adjustSelectionOffsetsAndCleanup,
-  mergeAdjacentSelectionsWithSameFormats,
   getSelection,
   upsertSelection,
 } from './edit-selection-helpers';
@@ -158,7 +159,7 @@ export default class EditPost extends React.Component {
   }
 
   async componentDidMount() {
-    console.log("EDIT - didMount")
+    console.debug("EDIT - didMount")
     try {
       window.addEventListener('resize', this.manageInsertMenu.bind(this));
       if (this.props.match.params.id === NEW_POST_URL_ID) {
@@ -175,7 +176,7 @@ export default class EditPost extends React.Component {
       if (this.props.match.params.id === prevProps.match.params.id) {
         return;
       }
-          console.log("EDIT - didUpdate")
+          console.debug("EDIT - didUpdate")
 
       this.setState({
         shouldRedirectToEditWithId: false,
@@ -193,7 +194,6 @@ export default class EditPost extends React.Component {
   documentModel = new EditDocumentModel();
   updateManager = new EditUpdateManager();
   commitTimeoutId;
-  cancelledEvent; // to coordinate noops between event types keydown, keyup
   inputRef;
 
   saveContentBatch = async () => {
@@ -210,13 +210,13 @@ export default class EditPost extends React.Component {
   }
 
   saveContentBatchDebounce() {
-    console.log("Batch Debounce");
+    console.debug("Batch Debounce");
     clearTimeout(this.commitTimeoutId);
     this.commitTimeoutId = setTimeout(this.saveContentBatch, 750);
   }
 
   newPost() {
-    console.log("New PostNew PostNew PostNew PostNew PostNew Post");
+    console.debug("New PostNew PostNew PostNew PostNew PostNew Post");
     const postPlaceholder = Map({ id: NEW_POST_URL_ID });
     this.updateManager.init(postPlaceholder);
     this.documentModel.init(postPlaceholder, this.updateManager);
@@ -378,17 +378,43 @@ export default class EditPost extends React.Component {
     }
     const selectedNode = getCaretNode();
     const selectedNodeType = getCaretNodeType();
+    const [caretPositionStart, _] = getOffsetInParentContent();
     const selectedNodeContent = cleanText(selectedNode.textContent);
-    if (range.startOffset > 0 && cleanText(selectedNodeContent)) {
-      // not at beginning of node text and node text isn't empty - don't override, it's just a normal backspace
-      return
-    }
     console.info('BACKSPACE node: ', selectedNode, ' content: ', selectedNodeContent);
 
     evt.stopPropagation();
     evt.preventDefault();
-    this.cancelledEvent = evt;
 
+    if (range.startOffset > 0 && cleanText(selectedNodeContent)) {
+      // TODO: move this to handleSyncToDom
+      //  not at beginning of node text and node text isn't empty - it's just a normal backspace, not a 'structural change' backspace
+      //  (although a selection could span across nodes and become structural)
+      const diffLength = Math.max(1, range.endOffset - range.startOffset);
+      if (diffLength === 1) {
+        // delete just one char
+        let selectedNodeMap = this.documentModel.getNode(selectedNodeId);
+        const beforeContentMap = selectedNodeMap.get('content') || '';
+        const updatedContentMap = `${beforeContentMap.slice(0, caretPositionStart - 1)}${beforeContentMap.slice(caretPositionStart)}`;
+        selectedNodeMap = selectedNodeMap.set('content', updatedContentMap);
+        selectedNodeMap = adjustSelectionOffsetsAndCleanup(selectedNodeMap, caretPositionStart, -diffLength);
+        this.documentModel.update(selectedNodeMap);
+        // TODO: use commitUpdates()
+        this.setState({
+          nodesByParentId: this.documentModel.nodesByParentId,
+        }, () => {
+            if (this.props.match.params.id !== NEW_POST_URL_ID) {
+              this.saveContentBatchDebounce();
+            }
+          // TODO: This is a hack.  Calling setState here will force all changed nodes to rerender.
+          //  The browser will then place the caret at the beginning of the textContent... 😞
+          setCaret(selectedNodeId, diffLength === 1 ? caretPositionStart - 1 : caretPositionStart);
+        });
+        return;
+      } else {
+        // TODO: a highlighted selection was deleted
+        return;
+      }
+    }
     /**
      * TODO: make these into sets of atomic commands that are added to a queue,
      *  then make a 'flush' command to process this queue.
@@ -436,7 +462,6 @@ export default class EditPost extends React.Component {
 
     evt.stopPropagation();
     evt.preventDefault();
-    this.cancelledEvent = evt;
 
     const range = getRange();
     if (!range) {
@@ -487,70 +512,69 @@ export default class EditPost extends React.Component {
    * NOTE (TODO?): we don't call setState({nodesByParentId... here. (except when typing a new Title on /edit/new)
    * The sync goes DOM -> JSModel only until the user formats a selection, hits enter or edits a section.
    * Calling setState({nodesByParentId... here causes issues with the caret position
+   * // TODO: handle cut/paste?
+    // TODO: handle select & type or select & delete
+    // TODO: 'Del' does it work at the edge of 2 selections?
    */
-  handleSyncFromDom(evt) {
-    if (
-      // cross event type cancellation keyDown -> keyUp, etc
-      this.cancelledEvent
-      // don't send updates for control keys
-      // TODO: this should probably use a diff strategy instead of key detection
-      || isControlKey(evt.keyCode)) {
+  handleSyncToDom(evt) {
+    // don't send updates for control keys
+    if (isControlKey(evt.keyCode)
+      // stopped by another handler like Backspace or Enter
+      || evt.isPropagationStopped()) {
       return;
     }
     const selectedNode = getCaretNode();
     const selectedNodeId = getCaretNodeId();
-    const selectedNodeContentDom = cleanText(selectedNode.textContent);
-
     if (selectedNodeId === 'null' || !selectedNodeId) {
       console.error('DOM SYNC - bad selection, no id ', selectedNode);
       return;
     }
-    // codel lines are stored differently
+    evt.stopPropagation();
+    evt.preventDefault();
+
+    // TODO: handle start != end (range is not collapsed)
+    const [caretPositionStart, caretPositionEnd]  = getOffsetInParentContent();
+
+    // TODO: code lines are stored differently, custom behavior
     if (selectedNode.tagName === 'PRE') {
-      handleDomSyncCode(this.documentModel, selectedNodeId, selectedNodeContentDom);
+      const beforeContentDom = cleanText(selectedNode.textContent);
+      const updatedContentDom = `${beforeContentDom.slice(0, caretPositionStart)}${evt.key}${beforeContentDom.slice(caretPositionStart)}`;
+      handleDomSyncCode(this.documentModel, selectedNodeId, updatedContentDom);
       console.debug('DOM SYNC PRE ', selectedNode);
       this.saveContentBatchDebounce();
       return;
     }
-    
+
     let selectedNodeMap = this.documentModel.getNode(selectedNodeId);
     // paragraph has selections?  adjust starts and ends of any that fall on or after the current caret position
-    const selectedNodeContentMap = selectedNodeMap.get('content') || '';
-    // TODO: handle diffStart != diffEnd (range is not collapsed)
-    const [diffStartDomRange, _] = this.keyDownCaretPosition;
-    const [diffStartFromTextDiff, diffLength] = getDiffStartAndLength(selectedNodeContentMap, selectedNodeContentDom);
-    // HACK: ugh, zero length char placeholder (so we can set the caret) causes this to be off by one when entering the first character in the title of a new post...
-    let diffStart = diffStartDomRange;
-    if (selectedNodeContentMap.length === 0) {
-      diffStart = diffStartFromTextDiff;
-    }
-    // TODO: handle cut/paste?
-    // TODO: handle select & type or select & delete
-    // TODO: 'Del' does it work at the edge of 2 selections?
-    if (diffLength === 0) {
-      return;
-    }
-    console.debug('DOM SYNC diff: ', diffStart, ' diffLen: ', diffLength, 'length: ', selectedNodeContentDom.length);
-    selectedNodeMap = selectedNodeMap.set('content', selectedNodeContentDom);
+    const beforeContentMap = selectedNodeMap.get('content') || '';
+    const updatedContentMap = `${beforeContentMap.slice(0, caretPositionStart)}${getCharFromEvent(evt)}${beforeContentMap.slice(caretPositionStart)}`;
+    const diffLength = updatedContentMap.length - beforeContentMap.length;
+
+    console.info('DOM SYNC diff: ', caretPositionStart, ' diffLen: ', diffLength, 'length: ', updatedContentMap.length);
+    selectedNodeMap = selectedNodeMap.set('content', updatedContentMap);
     // use the offset from 'onKeyDown' handler - before DOM was updated to know the caret start position
-    selectedNodeMap = adjustSelectionOffsetsAndCleanup(selectedNodeMap, diffStart, diffLength);
+    selectedNodeMap = adjustSelectionOffsetsAndCleanup(selectedNodeMap, caretPositionStart, diffLength);
     this.documentModel.update(selectedNodeMap);
-
-    if (this.props.match.params.id !== NEW_POST_URL_ID) {
-      this.saveContentBatchDebounce();
-      return;
-    }
-
-    // setState here to show/hide the title placeholder - only for an unsaved post!
+    // TODO use commitUpdates()
     this.setState({
       nodesByParentId: this.documentModel.nodesByParentId,
     }, () => {
+        if (this.props.match.params.id !== NEW_POST_URL_ID) {
+          this.saveContentBatchDebounce();
+        }
       // TODO: This is a hack.  Calling setState here will force all changed nodes to rerender.
       //  The browser will then place the caret at the beginning of the textContent... 😞
-      setCaret(selectedNodeId, diffStart + diffLength);
+      setCaret(selectedNodeId, caretPositionStart + diffLength);
     });
   }
 
+  handleSyncFromDom(evt) {
+    // Stop all updates to the contenteditable div!
+    evt.stopPropagation();
+    evt.preventDefault();
+    // TODO: detect emoji keyboard insert
+  }
 
   /**
    * Move caret for special user input cases
@@ -596,19 +620,26 @@ export default class EditPost extends React.Component {
   }
 
   handleKeyDown = (evt) => {
+    // any control keys being held down?
+    if (evt.metaKey || isControlKey(evt.keyCode)) {
+      return;
+    }
     //console.debug('KeyDown code: ', evt.keyCode, 'Node: ', getCaretNode(), ' offset ', getCaretOffset())
     this.handleBackspace(evt);
     this.handleEnter(evt);
-    this.keyDownCaretPosition = getOffsetInParentContent();
+    this.handleSyncToDom(evt);
   }
 
   handleKeyUp = (evt) => {
+    // any control keys being held down?
+    if (evt.metaKey) {
+      return;
+    }
     //console.debug('KeyUp Node: ', getCaretNode(), ' offset ', getCaretOffset())
     this.handleSyncFromDom(evt);
     this.handleCaret(evt);
     this.manageInsertMenu(evt);
     this.manageFormatSelectionMenu(evt);
-    this.cancelledEvent = null;
   }
 
   handleMouseUp = (evt) => {
@@ -628,23 +659,28 @@ export default class EditPost extends React.Component {
     const selectedNodeType = getCaretNodeType(selectedNode);
     const selectedNodeId = getCaretNodeId(selectedNode);
 
-    const [caretPosition] = getOffsetInParentContent();
+    const [caretPositionStart, _] = getOffsetInParentContent();
     // split selectedNodeContent at caret
-    const selectedNodeContent = cleanTextOrZeroLengthPlaceholder(selectedNode.textContent);
-    const domLines = evt.clipboardData.getData('text/plain').split('\n');
+    const clipboardText = evt.clipboardData.getData('text/plain');
 
     evt.stopPropagation();
     evt.preventDefault();
 
     let focusNodeId;
-    let focusIdx = selectedNodeContent.length;
+    let focusIdx = caretPositionStart;
     switch (selectedNodeType) {
       case NODE_TYPE_PRE: {
         [
           focusNodeId,
-          focusIdx
-        ] = handlePasteCode(this.documentModel, selectedNodeId, caretPosition, selectedNodeContent, domLines);
+          focusIdx,
+        ] = handlePasteCode(this.documentModel, selectedNodeId, caretPositionStart, clipboardText);
         break;
+      }
+      case NODE_TYPE_P: {
+        [
+          focusNodeId,
+          focusIdx,
+        ] = handlePasteParagraph(this.documentModel, selectedNodeId, caretPositionStart, clipboardText);
       }
       default: { /*NOOP*/
       }
@@ -923,11 +959,27 @@ export default class EditPost extends React.Component {
     const rect = range.getBoundingClientRect();
     const selectedNodeId = getCaretNodeId();
     const selectedNodeModel = this.documentModel.getNode(selectedNodeId);
+    // Top Offset (from top of document) - needs a heuristic!
+    // start with the top offset of the paragraph
+    const paragraphTop = selectedNode.offsetTop;
+    // get a percentage of where the start of the selection is relative to the length of the content
+    const percentageOfText = (startOffset / selectedNode.textContent.length);
+    // take that percentage from height of the paragraph
+    const percentageOffset = selectedNode.offsetHeight * percentageOfText;
+    // get closest clean division of the height of the selection (this sort of works)
+
+    let offsetByLineHeight = 0;
+    while (true) {
+      if (offsetByLineHeight + lineHeight > percentageOffset) {
+        break;
+      }
+      offsetByLineHeight += lineHeight;
+    }
     //const
     this.setState({
       formatSelectionNode: selectedNodeModel,
       formatSelectionModel: getSelection(selectedNodeModel, startOffset, endOffset),
-      formatSelectionMenuTopOffset: selectedNode.offsetTop,
+      formatSelectionMenuTopOffset: paragraphTop + offsetByLineHeight,
       formatSelectionMenuLeftOffset: (rect.left + rect.right) / 2,
     });
   }
@@ -1056,6 +1108,7 @@ export default class EditPost extends React.Component {
                 contentEditable={true}
                 suppressContentEditableWarning={true}
                 onKeyDown={this.handleKeyDown}
+                onKeyUp={this.handleKeyUp}
                 onInput={this.handleKeyUp}
                 onPaste={this.handlePaste}
               >
@@ -1073,6 +1126,7 @@ export default class EditPost extends React.Component {
             close={this.togglePostMenu}
             successMessage={shouldShowPostSuccess}
             errorMessage={shouldShowPostError}
+            forwardRef={this.getInputForwardedRef}
         />)}
         {shouldShowInsertMenu && (<InsertSectionMenu
             insertMenuTopOffset={insertMenuTopOffset}

--- a/frontend/src/pages/edit/format-selection-menu.jsx
+++ b/frontend/src/pages/edit/format-selection-menu.jsx
@@ -58,7 +58,7 @@ const IconH2 = styled(IconH2Svg)`
 `;
 
 export const FormatSelectionMenu = styled(LilBlackMenu)`
-  top: ${p => p.top - (p.shouldShowUrl ? 80 : 50)}px;
+  top: ${p => p.top - (p.shouldShowUrl ? 30 : 0)}px;
   left: ${p => p.left - 165}px; // 165 is half the width of the menu
 `;
 export const LinkInput = styled(DarkInput)`

--- a/frontend/src/pages/edit/handle-code.js
+++ b/frontend/src/pages/edit/handle-code.js
@@ -103,7 +103,9 @@ export function handleEnterCode(documentModel, selectedNodeId, caretPosition, co
   return `${selectedSectionId}-${lineIndex + 1}`;
 }
 
-export function handlePasteCode(documentModel, selectedNodeId, caretPosition, content, domLines) {
+export function handlePasteCode(documentModel, selectedNodeId, caretPosition, clipboardText) {
+  const domLines = clipboardText.split('\n');
+  const content = documentModel.getNode(selectedNodeId).get('content') || '';
   const contentLeft = content.substring(0, caretPosition);
   const contentRight = content.substring(caretPosition);
   const [selectedSectionId, selectedLineIdx] = getPreCodeSectionIdAndIndex(selectedNodeId);

--- a/frontend/src/pages/edit/handle-paragraph.js
+++ b/frontend/src/pages/edit/handle-paragraph.js
@@ -7,7 +7,7 @@ import {
   NODE_TYPE_SECTION_H2,
   NODE_TYPE_SECTION_SPACER
 } from '../../common/constants';
-import { splitSelectionsAtCaretOffset } from './edit-selection-helpers';
+import {formatSelections, splitSelectionsAtCaretOffset} from './edit-selection-helpers';
 
 export function handleBackspaceParagraph(documentModel, selectedNodeId) {
   const selectedSection = documentModel.getSection(selectedNodeId);
@@ -82,7 +82,7 @@ export function handleEnterParagraph(documentModel, selectedNodeId, caretPositio
   let leftNode = documentModel.getNode(selectedNodeId);
   let rightNode = documentModel.getNode(rightNodeId);
   [leftNode, rightNode] = splitSelectionsAtCaretOffset(leftNode, rightNode, caretPosition);
-  console.info('ENTER "paragraph" content left: ', contentLeft, 'content right: ', contentRight, 'left selections: ', leftNode.getIn(['meta', 'selections'], List()).toJS(), 'right selections: ', rightNode.getIn(['meta', 'selections'], List()).toJS());
+  console.info('ENTER "paragraph" content left: ', contentLeft, 'content right: ', contentRight, 'left selections: ', formatSelections(leftNode), 'right selections: ', formatSelections(rightNode));
   documentModel.update(leftNode.set('content', contentLeft));
   documentModel.update(rightNode);
   return rightNodeId;


### PR DESCRIPTION
This is a true first version of `filbert` I'm going to tag it `0.0.1`

- capture all edit intent with `onKeyDown`
- first, update the JS Model then sync back to DOM (this is different, previously the DOM `contenteditable` would be updated and then synced back to the JS Model - this caused problems with React when `contenteditable` changed the underlying HTML structure)
- this is a lot more work because we're not letting `contenteditable` do any magic anymore
- it's worth the work to get rid of suprises - React fatal error whitescreens are a non-starter