### PR TITLE
Undo by deltas

### DIFF
--- a/frontend/src/common/constants.js
+++ b/frontend/src/common/constants.js
@@ -98,5 +98,9 @@ export const DOM_TEXT_NODE_TYPE_ID = 3;
 
 // HISTORY - undo / redo
 export const HISTORY_KEY_NODE_UPDATES = 'nodeUpdates';
-export const HISTORY_KEY_UNDO_HISTORY = 'undoHistory';
-export const HISTORY_KEY_REDO_HISTORY = 'redoHistory';
+export const HISTORY_KEY_UNDO = 'undoHistory';
+export const HISTORY_KEY_REDO = 'redoHistory';
+export const HISTORY_KEY_UNDO_UPDATES = 'executeUpdates';
+export const HISTORY_KEY_UNDO_OFFSETS = 'executeOffsets';
+export const HISTORY_KEY_REDO_UPDATES = 'unexecuteUpdates';
+export const HISTORY_KEY_REDO_OFFSETS = 'unexecuteOffsets';

--- a/frontend/src/common/test-helpers.js
+++ b/frontend/src/common/test-helpers.js
@@ -1,5 +1,3 @@
-export const idRegExp = new RegExp(/[0-9a-f]{4}/);
-
 export function overrideConsole() {
   global.console = {
     info: jest.fn(),

--- a/frontend/src/common/utils.js
+++ b/frontend/src/common/utils.js
@@ -149,6 +149,6 @@ export function moreThanNCharsAreDifferent(left, right, n) {
   return false;
 }
 
-export function idIsValid(maybeId){
+export function idIsValid(maybeId) {
   return new RegExp(/[0-9a-f]{4}/).test(maybeId);
 }

--- a/frontend/src/common/utils.js
+++ b/frontend/src/common/utils.js
@@ -148,3 +148,7 @@ export function moreThanNCharsAreDifferent(left, right, n) {
   }
   return false;
 }
+
+export function idIsValid(maybeId){
+  return new RegExp(/[0-9a-f]{4}/).test(maybeId);
+}

--- a/frontend/src/common/utils.test.js
+++ b/frontend/src/common/utils.test.js
@@ -16,7 +16,7 @@ const {
   getCanonicalFromTitle,
   deleteContentRange
 } = require('./utils');
-const { idRegExp } = require('./test-helpers');
+const { idIsValid } = require('../common/utils');
 
 global.confirm = jest.fn().mockImplementation(arg => arg);
 
@@ -39,7 +39,7 @@ describe('utils', () => {
     );
   });
   test('s4', () => {
-    expect(idRegExp.test(s4())).toBe(true);
+    expect(idIsValid(s4())).toBe(true);
   });
   test('getMapWithId', () => {
     const objWithId = {
@@ -53,7 +53,7 @@ describe('utils', () => {
     };
     const map2 = getMapWithId(mapWithoutId);
     expect(Map.isMap(map2)).toBe(true);
-    expect(idRegExp.test(map2.get('id'))).toBe(true);
+    expect(idIsValid(map2.get('id'))).toBe(true);
     expect(map2.get('foo')).toBe('bar');
   });
   test('cleanTextOrZeroLengthPlaceholder', () => {
@@ -106,7 +106,7 @@ describe('utils', () => {
     // i.e. "a-sultry-stifling-midday-5940"
     const pieces = canonical.split('-');
     expect(pieces.length).toBe(5);
-    expect(idRegExp.test(pieces[pieces.length - 1])).toBe(true);
+    expect(idIsValid(pieces[pieces.length - 1])).toBe(true);
   });
   test('deleteContentRange', () => {
     const text = 'Someone must have been telling lies about Josef K.';

--- a/frontend/src/pages/edit/components/edit.jsx
+++ b/frontend/src/pages/edit/components/edit.jsx
@@ -376,16 +376,18 @@ export default class EditPost extends React.Component {
     const {
       state: { nodesById }
     } = this;
+    // this pops the undo/redo stack AND applies the updates to the document (nodesById)
     const historyEntry = shouldUndo
       ? this.updateManager.undo(nodesById)
       : this.updateManager.redo(nodesById);
-    const historyNodesById = historyEntry.get('nodesById', Map());
+    const updatedNodesById = historyEntry.get('nodesById', Map());
     const historyOffsets = historyEntry.get('selectionOffsets', Map());
-    if (historyNodesById.size === 0) {
+    if (updatedNodesById.size === 0) {
       return;
     }
     console.info(`${shouldUndo ? 'UNDO!' : 'REDO!'}`);
-    this.documentModel.nodesById = historyNodesById;
+    this.documentModel.nodesById = updatedNodesById;
+    // passing undefined as prevSelectionOffsets will skip adding this operation to history again
     this.commitUpdates(undefined, historyOffsets.toJS());
   };
 
@@ -398,7 +400,7 @@ export default class EditPost extends React.Component {
     return new Promise((resolve /* , reject */) => {
       const {
         state: {
-          // these are the previous nodes - the updated ones are still in this.documentModel.nodesById
+          // these are the "clean" nodes - the updated (dirty) ones are in this.documentModel.nodesById (and this.updateManager.nodeUpdates)
           nodesById: prevNodesById,
           post
         }

--- a/frontend/src/pages/edit/document-model.js
+++ b/frontend/src/pages/edit/document-model.js
@@ -14,7 +14,7 @@ import {
   SELECTION_END,
   SELECTION_START
 } from '../../common/constants';
-import { cleanText, getMapWithId } from '../../common/utils';
+import { cleanText, getMapWithId, idIsValid } from '../../common/utils';
 import { concatSelections, Selection } from './selection-helpers';
 
 export function reviver(key, value) {
@@ -32,6 +32,10 @@ export default class DocumentModel {
 
   nodesById = Map();
 
+  static nodeIsValid(node) {
+    return Map.isMap(node) && idIsValid(node.get('id'));
+  }
+  
   static getFirstNode(nodesById) {
     const idSeen = new Set();
     const nextSeen = new Set();
@@ -174,7 +178,7 @@ export default class DocumentModel {
       left = concatSelections(left, right);
     }
     this.update(left);
-    this.delete(rightId);
+    this.delete(right);
   }
 
   insert(

--- a/frontend/src/pages/edit/document-model.js
+++ b/frontend/src/pages/edit/document-model.js
@@ -35,7 +35,7 @@ export default class DocumentModel {
   static nodeIsValid(node) {
     return Map.isMap(node) && idIsValid(node.get('id'));
   }
-  
+
   static getFirstNode(nodesById) {
     const idSeen = new Set();
     const nextSeen = new Set();

--- a/frontend/src/pages/edit/document-model.js
+++ b/frontend/src/pages/edit/document-model.js
@@ -217,14 +217,14 @@ export default class DocumentModel {
 
   update(node) {
     const nodeId = node.get('id');
-    this.updateManager.stageNodeUpdate(nodeId);
+    this.updateManager.stageNodeUpdate(node);
     this.nodesById = this.nodesById.set(nodeId, node);
     return nodeId;
   }
 
-  delete(nodeId) {
-    // mark this node deleted
-    this.updateManager.stageNodeDelete(nodeId);
+  delete(node) {
+    const nodeId = node.get('id');
+    this.updateManager.stageNodeDelete(node);
     const prevNode = this.getPrevNode(nodeId);
     const nextNode = this.getNextNode(nodeId);
     // delete first, then update pointers
@@ -242,5 +242,6 @@ export default class DocumentModel {
       this.update(prevNode.delete('next_sibling_id'));
     }
     // else - deleting first node - noop
+    // TODO: just replace with an empty P?
   }
 }

--- a/frontend/src/pages/edit/test/__snapshots__/document-model.test.js.snap
+++ b/frontend/src/pages/edit/test/__snapshots__/document-model.test.js.snap
@@ -418,7 +418,6 @@ DocumentModel {
     "id": 175,
   },
   "updateManager": Object {
-    "nodeHasBeenStagedForDelete": [MockFunction],
     "stageNodeDelete": [MockFunction],
     "stageNodeUpdate": [MockFunction],
   },

--- a/frontend/src/pages/edit/test/__snapshots__/update-manager.test.js.snap
+++ b/frontend/src/pages/edit/test/__snapshots__/update-manager.test.js.snap
@@ -3,7 +3,8 @@
 exports[`UpdateManager init method 1`] = `
 UpdateManager {
   "commitTimeoutId": undefined,
-  "lastUndoHistoryPush": undefined,
+  "lastUndoHistoryNode": Immutable.Map {},
+  "lastUndoHistoryOffsets": undefined,
   "post": Immutable.Map {
     "abstract": "Creating a simple React ( + Babel + Webpack + yarn) starter project is actually proving to be difficult starting from the documentation.",
     "created": "2019-05-18 17:28:55",
@@ -23,7 +24,8 @@ UpdateManager {
 exports[`UpdateManager stageNodeDelete method 1`] = `
 UpdateManager {
   "commitTimeoutId": undefined,
-  "lastUndoHistoryPush": undefined,
+  "lastUndoHistoryNode": Immutable.Map {},
+  "lastUndoHistoryOffsets": undefined,
   "post": Immutable.Map {
     "abstract": "Creating a simple React ( + Babel + Webpack + yarn) starter project is actually proving to be difficult starting from the documentation.",
     "created": "2019-05-18 17:28:55",
@@ -43,7 +45,8 @@ UpdateManager {
 exports[`UpdateManager stageNodeUpdate method 1`] = `
 UpdateManager {
   "commitTimeoutId": undefined,
-  "lastUndoHistoryPush": undefined,
+  "lastUndoHistoryNode": Immutable.Map {},
+  "lastUndoHistoryOffsets": undefined,
   "post": Immutable.Map {
     "abstract": "Creating a simple React ( + Babel + Webpack + yarn) starter project is actually proving to be difficult starting from the documentation.",
     "created": "2019-05-18 17:28:55",
@@ -58,36 +61,4 @@ UpdateManager {
   "saveContentBatch": [Function],
   "saveContentBatchDebounce": [Function],
 }
-`;
-
-exports[`UpdateManager updates method 1`] = `
-Array [
-  Array [
-    "foo",
-    Object {
-      "action": "update",
-      "node": Object {
-        "id": "foo",
-      },
-      "post_id": 1,
-    },
-  ],
-  Array [
-    "qux",
-    Object {
-      "action": "update",
-      "node": Object {
-        "id": "qux",
-      },
-      "post_id": 1,
-    },
-  ],
-  Array [
-    "bar",
-    Object {
-      "action": "delete",
-      "post_id": 1,
-    },
-  ],
-]
 `;

--- a/frontend/src/pages/edit/test/document-model.test.js
+++ b/frontend/src/pages/edit/test/document-model.test.js
@@ -10,8 +10,7 @@ import { testPostWithAllTypesJS } from './test-post-with-all-types';
 overrideConsole();
 const updateManagerMock = {
   stageNodeUpdate: jest.fn(),
-  stageNodeDelete: jest.fn(),
-  nodeHasBeenStagedForDelete: jest.fn()
+  stageNodeDelete: jest.fn()
 };
 
 const { post, contentNodes } = testPostWithAllTypesJS;

--- a/frontend/src/pages/edit/test/document-model.test.js
+++ b/frontend/src/pages/edit/test/document-model.test.js
@@ -1,6 +1,6 @@
 import { Map } from 'immutable';
 import { NODE_TYPE_H1 } from '../../../common/constants';
-import { idRegExp, overrideConsole } from '../../../common/test-helpers';
+import { overrideConsole } from '../../../common/test-helpers';
 
 import * as SelectionHelpers from '../selection-helpers';
 
@@ -31,11 +31,11 @@ describe('DocumentModel', () => {
       documentModel.nodesById
     );
     expect(placeholderTitle.get('type')).toBe(NODE_TYPE_H1);
-    expect(idRegExp.test(placeholderTitle.get('id'))).toBe(true);
+    expect(DocumentModel.nodeIsValid(placeholderTitle)).toBe(true);
   });
   test('getMapWithId', () => {
     const result = documentModel.getMapWithId({});
-    expect(idRegExp.test(result.get('id'))).toBe(true);
+    expect(DocumentModel.nodeIsValid(result)).toBe(true);
     expect(result.get('post_id')).toBe(175);
   });
   test('getNode', () => {

--- a/frontend/src/pages/edit/test/update-manager.test.js
+++ b/frontend/src/pages/edit/test/update-manager.test.js
@@ -64,12 +64,6 @@ describe('UpdateManager', () => {
     updateManager.stageNodeDelete('foo');
     expect(updateManager).toMatchSnapshot();
   });
-  test('nodeHasBeenStagedForDelete method', () => {
-    updateManager.stageNodeUpdate('foo');
-    expect(updateManager.nodeHasBeenStagedForDelete('foo')).toBe(false);
-    updateManager.stageNodeDelete('foo');
-    expect(updateManager.nodeHasBeenStagedForDelete('foo')).toBe(true);
-  });
   test('addPostIdToUpdates method', () => {
     // mimic a "not-yet-saved" post
     updateManager.init({});

--- a/frontend/src/pages/edit/test/update-manager.test.js
+++ b/frontend/src/pages/edit/test/update-manager.test.js
@@ -41,13 +41,14 @@ describe('UpdateManager', () => {
     expect(updateManager.nodeUpdates.size).toBe(0);
     updateManager.stageNodeUpdate(null);
     expect(updateManager.nodeUpdates.size).toBe(0);
-    updateManager.stageNodeUpdate('null');
+    updateManager.stageNodeUpdate(Map({id:'null'}));
     expect(updateManager.nodeUpdates.size).toBe(0);
-    updateManager.stageNodeUpdate('undefined');
+    updateManager.stageNodeUpdate(Map({id:'undefined'}));
     expect(updateManager.nodeUpdates.size).toBe(0);
     // test that last-write-wins, update overwrites delete
-    updateManager.stageNodeDelete('foo');
-    updateManager.stageNodeUpdate('foo');
+    updateManager.stageNodeDelete(Map({id:'1234'}));
+    updateManager.stageNodeUpdate(Map({id:'1234'}));
+    expect(updateManager.nodeUpdates.size).toBe(1);
     expect(updateManager).toMatchSnapshot();
   });
   test('stageNodeDelete method', () => {
@@ -55,41 +56,27 @@ describe('UpdateManager', () => {
     expect(updateManager.nodeUpdates.size).toBe(0);
     updateManager.stageNodeDelete(null);
     expect(updateManager.nodeUpdates.size).toBe(0);
-    updateManager.stageNodeDelete('null');
+    updateManager.stageNodeDelete(Map({id:'null'}));
     expect(updateManager.nodeUpdates.size).toBe(0);
-    updateManager.stageNodeDelete('undefined');
+    updateManager.stageNodeDelete(Map({id:'undefined'}));
     expect(updateManager.nodeUpdates.size).toBe(0);
     // test that last-write-wins, delete overwrites update
-    updateManager.stageNodeUpdate('foo');
-    updateManager.stageNodeDelete('foo');
+    updateManager.stageNodeUpdate(Map({id:'1234'}));
+    updateManager.stageNodeDelete(Map({id:'1234'}));
     expect(updateManager).toMatchSnapshot();
   });
   test('addPostIdToUpdates method', () => {
     // mimic a "not-yet-saved" post
     updateManager.init({});
-    updateManager.stageNodeUpdate('bar');
-    expect(updateManager.nodeUpdates.get('bar').get('post_id')).toBeUndefined();
+    updateManager.stageNodeUpdate(Map({id:'abcd'}));
+    expect(updateManager.nodeUpdates.get('abcd').get('post_id')).toBeUndefined();
     updateManager.addPostIdToUpdates(1);
-    expect(updateManager.nodeUpdates.get('bar').get('post_id')).toBe(1);
-  });
-  test('updates method', () => {
-    // filter out ids that are "falsy", "null" or not found in the documentModel
-    updateManager.stageNodeUpdate('foo');
-    updateManager.stageNodeUpdate('qux');
-    updateManager.stageNodeDelete('bar');
-    updateManager.stageNodeUpdate('badId');
-    const documentModelMock = {
-      getNode: jest
-        .fn()
-        .mockImplementation(id => (id === 'badId' ? Map() : Map({ id })))
-    };
-    const updatesJS = updateManager.updates(documentModelMock);
-    expect(updatesJS).toMatchSnapshot();
+    expect(updateManager.nodeUpdates.get('abcd').get('post_id')).toBe(1);
   });
   test('clearUpdates method', () => {
-    updateManager.stageNodeUpdate('foo');
-    updateManager.stageNodeUpdate('qux');
-    updateManager.stageNodeDelete('bar');
+    updateManager.stageNodeUpdate(Map({id:'1111'}));
+    updateManager.stageNodeUpdate(Map({id:'abcd'}));
+    updateManager.stageNodeDelete(Map({id:'2222'}));
     expect(updateManager.nodeUpdates.size).toBe(3);
     updateManager.clearUpdates();
     expect(updateManager.nodeUpdates.size).toBe(0);
@@ -97,4 +84,11 @@ describe('UpdateManager', () => {
     updateManager.clearUpdates();
     expect(updateManager.nodeUpdates.size).toBe(0);
   });
+  test.todo('addToUndoHistory');
+  test.todo('applyUpdates');
+  test.todo('undo');
+  test.todo('redo');
+  test.todo('getters / setters');
+  test.todo('saveContentBatch');
+  test.todo('saveContentDebounce');
 });

--- a/frontend/src/pages/edit/test/update-manager.test.js
+++ b/frontend/src/pages/edit/test/update-manager.test.js
@@ -41,13 +41,13 @@ describe('UpdateManager', () => {
     expect(updateManager.nodeUpdates.size).toBe(0);
     updateManager.stageNodeUpdate(null);
     expect(updateManager.nodeUpdates.size).toBe(0);
-    updateManager.stageNodeUpdate(Map({id:'null'}));
+    updateManager.stageNodeUpdate(Map({ id: 'null' }));
     expect(updateManager.nodeUpdates.size).toBe(0);
-    updateManager.stageNodeUpdate(Map({id:'undefined'}));
+    updateManager.stageNodeUpdate(Map({ id: 'undefined' }));
     expect(updateManager.nodeUpdates.size).toBe(0);
     // test that last-write-wins, update overwrites delete
-    updateManager.stageNodeDelete(Map({id:'1234'}));
-    updateManager.stageNodeUpdate(Map({id:'1234'}));
+    updateManager.stageNodeDelete(Map({ id: '1234' }));
+    updateManager.stageNodeUpdate(Map({ id: '1234' }));
     expect(updateManager.nodeUpdates.size).toBe(1);
     expect(updateManager).toMatchSnapshot();
   });
@@ -56,27 +56,29 @@ describe('UpdateManager', () => {
     expect(updateManager.nodeUpdates.size).toBe(0);
     updateManager.stageNodeDelete(null);
     expect(updateManager.nodeUpdates.size).toBe(0);
-    updateManager.stageNodeDelete(Map({id:'null'}));
+    updateManager.stageNodeDelete(Map({ id: 'null' }));
     expect(updateManager.nodeUpdates.size).toBe(0);
-    updateManager.stageNodeDelete(Map({id:'undefined'}));
+    updateManager.stageNodeDelete(Map({ id: 'undefined' }));
     expect(updateManager.nodeUpdates.size).toBe(0);
     // test that last-write-wins, delete overwrites update
-    updateManager.stageNodeUpdate(Map({id:'1234'}));
-    updateManager.stageNodeDelete(Map({id:'1234'}));
+    updateManager.stageNodeUpdate(Map({ id: '1234' }));
+    updateManager.stageNodeDelete(Map({ id: '1234' }));
     expect(updateManager).toMatchSnapshot();
   });
   test('addPostIdToUpdates method', () => {
     // mimic a "not-yet-saved" post
     updateManager.init({});
-    updateManager.stageNodeUpdate(Map({id:'abcd'}));
-    expect(updateManager.nodeUpdates.get('abcd').get('post_id')).toBeUndefined();
+    updateManager.stageNodeUpdate(Map({ id: 'abcd' }));
+    expect(
+      updateManager.nodeUpdates.get('abcd').get('post_id')
+    ).toBeUndefined();
     updateManager.addPostIdToUpdates(1);
     expect(updateManager.nodeUpdates.get('abcd').get('post_id')).toBe(1);
   });
   test('clearUpdates method', () => {
-    updateManager.stageNodeUpdate(Map({id:'1111'}));
-    updateManager.stageNodeUpdate(Map({id:'abcd'}));
-    updateManager.stageNodeDelete(Map({id:'2222'}));
+    updateManager.stageNodeUpdate(Map({ id: '1111' }));
+    updateManager.stageNodeUpdate(Map({ id: 'abcd' }));
+    updateManager.stageNodeDelete(Map({ id: '2222' }));
     expect(updateManager.nodeUpdates.size).toBe(3);
     updateManager.clearUpdates();
     expect(updateManager.nodeUpdates.size).toBe(0);

--- a/frontend/src/pages/edit/update-manager.js
+++ b/frontend/src/pages/edit/update-manager.js
@@ -1,6 +1,6 @@
 import { fromJS, List, Map } from 'immutable';
 
-import DocumentModel from './document-model';
+import DocumentModel, { reviver } from './document-model';
 import {
   HISTORY_KEY_NODE_UPDATES,
   HISTORY_KEY_REDO,
@@ -17,15 +17,15 @@ import {
 import { apiPost } from '../../common/fetch';
 import { get, set } from '../../common/local-storage';
 import { moreThanNCharsAreDifferent } from '../../common/utils';
-import { reviver } from './document-model';
 
 const characterDiffSize = 6;
 
 export default class UpdateManager {
   commitTimeoutId;
-  
+
   // cache last node for text changes, so we don't add a history entry for every keystroke
   lastUndoHistoryNode = Map();
+
   lastUndoHistoryOffsets;
 
   post = Map();

--- a/frontend/src/pages/edit/update-manager.js
+++ b/frontend/src/pages/edit/update-manager.js
@@ -23,10 +23,9 @@ const characterDiffSize = 6;
 
 export default class UpdateManager {
   commitTimeoutId;
-
+  
+  // cache last node for text changes, so we don't add a history entry for every keystroke
   lastUndoHistoryNode = Map();
-
-  // cache one node for text changes, so we don't add a history entry for every keystroke
   lastUndoHistoryOffsets;
 
   post = Map();
@@ -111,9 +110,9 @@ export default class UpdateManager {
           return update.set('node', prevNode);
         }
         // At this point, changes should be local to one text content field of one node.
-        // Cache the node to refer back to on subsequent diff checks
+        // Cache the node to refer back to on subsequent diff checks (for each keystroke on the same node)
         if (this.lastUndoHistoryNode.get('id') !== nodeId) {
-          this.lastUndoHistoryNode = update.get('node');
+          this.lastUndoHistoryNode = prevNode;
           this.lastUndoHistoryOffsets = prevSelectionOffsets;
         }
         // content can live in a few different places: ('content', ['meta':'url', 'caption', 'author', 'context', 'quote'], ['meta':'selections':N:'linkUrl'] - add if enough characters changed

--- a/frontend/src/pages/edit/update-manager.js
+++ b/frontend/src/pages/edit/update-manager.js
@@ -1,5 +1,6 @@
 import { fromJS, List, Map } from 'immutable';
 
+import DocumentModel from './document-model';
 import {
   HISTORY_KEY_NODE_UPDATES,
   HISTORY_KEY_REDO,
@@ -218,11 +219,7 @@ export default class UpdateManager {
   };
 
   stageNodeDelete(node) {
-    if (
-      !node ||
-      node.size === 0 ||
-      ['null', 'undefined'].includes(node.get('id'))
-    ) {
+    if (!DocumentModel.nodeIsValid(node)) {
       console.error('stageNodeDelete - bad node', node);
       return;
     }
@@ -242,11 +239,7 @@ export default class UpdateManager {
   }
 
   stageNodeUpdate(node) {
-    if (
-      !node ||
-      node.size === 0 ||
-      ['null', 'undefined'].includes(node.get('id'))
-    ) {
+    if (!DocumentModel.nodeIsValid(node)) {
       console.error('stageNodeUpdate - bad node', node);
       return;
     }


### PR DESCRIPTION
Change the undo data resolution from "document" to "node".  Saving a copy of the document for every undo doesn't even work at small scale, so save nodes instead.  The next optimization will be node deltas instead of whole nodes.