### PR TITLE
refactor deleteNode for backspace (merge), select-and-type, cut & paste (no merge) operations

### DIFF
--- a/lib/document/document-model.mjs
+++ b/lib/document/document-model.mjs
@@ -1,8 +1,12 @@
 import Immutable, { Map } from 'immutable';
 
-import { NEW_POST_URL_ID } from '@filbert/constants';
 import { cleanText, getMapWithId } from '@filbert/util';
-import { concatSelections, reviver } from '@filbert/selection';
+import {
+  adjustSelectionOffsetsAndCleanup,
+  concatSelections,
+  reviver,
+} from '@filbert/selection';
+import { deleteContentRange } from 'filbert-web/src/common/utils.js';
 
 // for document container
 export const NODE_TYPE_ROOT = 'root';
@@ -138,10 +142,6 @@ export function DocumentModel(postId, jsonData = null) {
 
   if (jsonData) {
     nodesById = Immutable.fromJS(jsonData, reviver);
-  }
-
-  function isUnsavedPost() {
-    return postId === NEW_POST_URL_ID;
   }
 
   function getNodes() {
@@ -323,13 +323,21 @@ export function DocumentModel(postId, jsonData = null) {
     return history;
   }
 
-  // returns a nodeId to be "focused"
   function deleteNode(node) {
     const history = [];
     const nodeId = node.get('id');
     const prevNode = getPrevNode(nodeId);
     const nextNode = getNextNode(nodeId);
 
+    // don't delete last node in document, reset it to an empty title
+    if (!prevNode.size && !nextNode.size) {
+      history.push(
+        ...update(
+          node.set('type', NODE_TYPE_H1).set('content', '').set('meta', Map())
+        )
+      );
+      return history;
+    }
     // update pointers first
     // deleting somewhere in the middle
     if (prevNode.get('id') && nextNode.get('id')) {
@@ -347,6 +355,52 @@ export function DocumentModel(postId, jsonData = null) {
     nodesById = nodesById.delete(nodeId);
 
     return history;
+  }
+
+  // returns a nodeId for node deleted, false for node updated
+  function deleteNodeContentRangeAndUpdateSelections(
+    diffLength,
+    nodeId,
+    startIdx
+  ) {
+    let node = getNode(nodeId);
+    const content = node.get('content', '');
+    /* TODO: delete node under if all content has been highlighted
+    if (startIdx === 0 && diffLength >= content.length) {
+      return documentModel.deleteNode(node);
+    } */
+    // only some of endNode's content has been selected, delete that content
+    node = node.set(
+      'content',
+      deleteContentRange(content, startIdx, diffLength)
+    );
+    node = adjustSelectionOffsetsAndCleanup(
+      node,
+      content,
+      startIdx + diffLength,
+      // -1 for "regular" backspace to delete 1 char
+      diffLength === 0 ? -1 : -diffLength
+    );
+    return update(node);
+  }
+
+  // given selectionOffsets - return 2 boolean values for {willDeleteStartNode, willDeleteEndNode}
+  function willDeleteStartAndEnd({
+    startNodeId,
+    caretStart,
+    endNodeId,
+    caretEnd,
+  }) {
+    const willDeleteStartNode =
+      isMetaType(startNodeId) ||
+      (endNodeId && caretStart === 0) ||
+      (caretStart === 0 &&
+        caretEnd === getNode(startNodeId).get('content', '').length);
+    const willDeleteEndNode =
+      endNodeId &&
+      (isMetaType(endNodeId) ||
+        caretEnd === getNode(endNodeId).get('content', '').length);
+    return { willDeleteStartNode, willDeleteEndNode };
   }
 
   function mergeParagraphs(leftId, rightId) {
@@ -371,7 +425,6 @@ export function DocumentModel(postId, jsonData = null) {
   }
 
   return {
-    isUnsavedPost,
     getNodes,
     setNodes,
     getNode,
@@ -387,6 +440,8 @@ export function DocumentModel(postId, jsonData = null) {
     update,
     insert,
     deleteNode,
+    deleteNodeContentRangeAndUpdateSelections,
+    willDeleteStartAndEnd,
     mergeParagraphs,
   };
 }

--- a/lib/history/history-manager.mjs
+++ b/lib/history/history-manager.mjs
@@ -41,10 +41,6 @@ export function HistoryManager(postId, apiClient) {
   let historyLog = [];
   let hasPendingRequest = false;
 
-  function getLocalHistoryLog() {
-    return historyLog;
-  }
-
   function clearPending() {
     // clear cache
     historyCandidateState = Map();
@@ -115,7 +111,7 @@ export function HistoryManager(postId, apiClient) {
     historyLog.push(historyEntry);
   }
 
-  async function saveAndClearLocalHistoryLog() {
+  async function saveAndClearLocalHistoryLog(postIdOverride) {
     if (hasPendingRequest) {
       return { throttled: true };
     }
@@ -125,7 +121,7 @@ export function HistoryManager(postId, apiClient) {
     }
 
     hasPendingRequest = true;
-    const { error, data: result } = await apiClient.post(`/content/${postId}`, {
+    const { error, data: result } = await apiClient.post(`/content/${postIdOverride || postId}`, {
       contentNodeHistoryLog: historyLog,
     });
     hasPendingRequest = false;
@@ -217,7 +213,6 @@ export function HistoryManager(postId, apiClient) {
   }
 
   return {
-    getLocalHistoryLog,
     saveAndClearLocalHistoryLog,
     flushPendingHistoryLogEntry,
     appendToHistoryLog,

--- a/lib/history/history-manager.mjs
+++ b/lib/history/history-manager.mjs
@@ -121,9 +121,12 @@ export function HistoryManager(postId, apiClient) {
     }
 
     hasPendingRequest = true;
-    const { error, data: result } = await apiClient.post(`/content/${postIdOverride || postId}`, {
-      contentNodeHistoryLog: historyLog,
-    });
+    const { error, data: result } = await apiClient.post(
+      `/content/${postIdOverride || postId}`,
+      {
+        contentNodeHistoryLog: historyLog,
+      }
+    );
     hasPendingRequest = false;
 
     if (error) {
@@ -134,7 +137,7 @@ export function HistoryManager(postId, apiClient) {
     // clear the pending history queue after successful save
     console.info('Save History Batch result', historyLog, result);
     historyLog = [];
-    return result;
+    return fromJS(result);
   }
 
   function appendToHistoryLogWhenNCharsAreDifferent({

--- a/web/src/common/dom.js
+++ b/web/src/common/dom.js
@@ -532,20 +532,8 @@ export function getImageFileFormData(file, post) {
   return formData;
 }
 
-export function selectionOffsetsAreEqual(left = {}, right = {}) {
-  let areEqual = true;
-  if (Object.keys(left).length === 0 || Object.keys(right).length === 0) {
-    return false;
-  }
-  const shorter =
-    Object.keys(left).length > Object.keys(right).length ? right : left;
-  const other = left === shorter ? right : left;
-  Object.entries(shorter).forEach(([key, value]) => {
-    if (other[key] !== value) {
-      areEqual = false;
-    }
-  });
-  return areEqual;
+export function isCollapsed({ caretStart, caretEnd, endNodeId }) {
+  return !endNodeId && (!caretEnd || caretStart === caretEnd);
 }
 
 export function isValidDomSelection({ startNodeId }) {

--- a/web/src/editor-components/EditImageMenu.svelte
+++ b/web/src/editor-components/EditImageMenu.svelte
@@ -26,7 +26,7 @@
     focusAndScrollSmooth,
   } from '../common/dom';
   import { stopAndPrevent } from '../common/utils';
-  import {currentPost } from "../stores";
+  import { currentPost } from '../stores';
 
   import IconButton from '../form-components/IconButton.svelte';
   import Cursor from '../form-components/Cursor.svelte';

--- a/web/src/editor-components/editor-commands/delete.js
+++ b/web/src/editor-components/editor-commands/delete.js
@@ -1,241 +1,300 @@
 /* eslint-disable import/prefer-default-export */
-import { assertValidDomSelectionOrThrow } from '../../common/dom';
-import { deleteContentRange } from '../../common/utils';
-import { getFirstNode } from '@filbert/document';
-import { adjustSelectionOffsetsAndCleanup } from '@filbert/selection';
+import { cleanText } from '@filbert/util';
+import { isCollapsed } from '../../common/dom';
 
-// returns a nodeId for node deleted, false for node updated
-function updateNode(documentModel, diffLength, nodeId, startIdx) {
-  let node = documentModel.getNode(nodeId);
-  const content = node.get('content', '');
-  /* TODO: delete node under if all content has been highlighted
-  if (startIdx === 0 && diffLength >= content.length) {
-    return documentModel.deleteNode(node);
-  } */
-  // only some of endNode's content has been selected, delete that content
-  node = node.set('content', deleteContentRange(content, startIdx, diffLength));
-  node = adjustSelectionOffsetsAndCleanup(
-    node,
-    content,
-    startIdx + diffLength,
-    // -1 for "regular" backspace to delete 1 char
-    diffLength === 0 ? -1 : -diffLength
-  );
-  return documentModel.update(node);
-}
-
-function buildDeleteHistory(
+export function doDeleteSingleNode(
   documentModel,
-  { startNodeId, caretStart, endNodeId, caretEnd }
+  historyManager,
+  selectionOffsets
 ) {
-  const historyState = [];
-  // TODO: make this step last, aka orphan these nodes first
-  // if there are completely highlighted nodes in the middle of the selection - just delete them
-  if (endNodeId) {
-    const middle = documentModel.getNodesBetween(startNodeId, endNodeId);
-    console.info('doDelete() - middle nodes', middle);
-    middle.forEach((node) => {
-      historyState.push(...documentModel.deleteNode(node));
-    });
-  }
-
-  /**
-   * the selection spans more than one node
-   * 1 - delete the highlighted text
-   * 2 - set the currentNodeId to the endNode
-   * 3 - no "structural" updates for delete operations as part of other Commands
-   */
-  // default the selectedNode to "startNode" - it can change to endNode below
-  let selectedNodeId = startNodeId;
-  let didDeleteEndNode = false;
-  if (endNodeId) {
-    // all of the endNode's content has been selected, delete it and set the selectedNodeId to the next sibling
-    // end diff length is caretEnd - 0 (implied caretStart for the end node)
-    if (caretEnd > 0) {
-      historyState.push(...updateNode(documentModel, caretEnd, endNodeId, 0));
-      selectedNodeId = documentModel.getLastInsertId();
-    }
-    didDeleteEndNode = selectedNodeId !== endNodeId;
-  }
-
-  const startNodeMap = documentModel.getNode(startNodeId);
-  const startNodeContent = startNodeMap.get('content');
-
-  // if there's an endNodeId - startNode has been selected from caretStart through the end
-  const startDiffLength =
-    (endNodeId ? startNodeContent.length : caretEnd) - caretStart;
-
-  return {
-    didDeleteEndNode,
-    selectedNodeId,
-    startNodeContent,
-    startDiffLength,
-    historyState,
-  };
-}
-
-export function doDeleteMetaType(documentModel, selectionOffsets) {
-  assertValidDomSelectionOrThrow(selectionOffsets);
-  // eslint-disable-next-line prefer-const
-  let { startNodeId } = selectionOffsets;
-  console.info('doDeleteMetaType()', selectionOffsets);
-
-  // if Meta Type
-  if (!documentModel.isMetaType(startNodeId)) {
-    throw new Error(
-      `Expecting MetaType node\n${JSON.stringify(selectionOffsets, null, 2)}`
-    );
-  }
-  const wasFirstNodeInDocument =
-    getFirstNode(documentModel.getNodes()).get('id') === startNodeId;
-  const prevNodeId = wasFirstNodeInDocument
-    ? getFirstNode(documentModel.getNodes()).get('id')
-    : documentModel.getPrevNode(startNodeId).get('id');
-  const historyState = documentModel.deleteNode(
-    documentModel.getNode(startNodeId)
+  const { startNodeId, caretStart, caretEnd } = selectionOffsets;
+  const caretIsCollapsed = isCollapsed(selectionOffsets);
+  const { willDeleteStartNode } = documentModel.willDeleteStartAndEnd(
+    selectionOffsets
   );
 
-  return {
-    historyState,
-    selectionOffsets: {
-      startNodeId: prevNodeId,
-      caretStart:
-        wasFirstNodeInDocument || documentModel.isMetaType(prevNodeId) ? 0 : -1,
-    },
-  };
-}
+  // ignore for select-and-type, cut & paste replace actions
+  if (caretIsCollapsed) {
+    return;
+  }
 
-/**
- *
- * @param documentModel DocumentModel
- * @param caretStart
- * @param caretEnd
- * @param startNodeId
- * @param endNodeId
- * @returns {{}|{startNodeId: *, caretStart: number}|{startNodeId: *, caretStart: *}}
- *
- * This one does the delete operation AND commits it as an atomic operation (aka adds a history entry)
- */
-export function doDelete(documentModel, selectionOffsets) {
-  assertValidDomSelectionOrThrow(selectionOffsets);
-  // eslint-disable-next-line prefer-const
-  let { caretStart, startNodeId, endNodeId } = selectionOffsets;
-  console.info('doDelete()', selectionOffsets);
+  console.debug('Delete - SINGLE NODE - no merge');
 
-  /**
-   * Backspace scenarios:
-   *
-   * 1) caret is collapsed OR
-   * 2) caret highlights 1 or more characters
-   * 3) caretStart === 0
-   * 4) caretEnd === selectedNodeMap.get('content').length
-   * 5) caret start and end nodes are different (multi-node selection)
-   * 6) there are middle nodes (this is easy, just delete them)
-   * 7) merge (heal) content from two different nodes
-   * 8) startNode is completely selected
-   * 9) endNode is completely selected
-   * 10) startNode and endNode are the same type
-   */
-  const buildDeleteResult = buildDeleteHistory(documentModel, selectionOffsets);
-  const { didDeleteEndNode, startDiffLength, historyState } = buildDeleteResult;
-  let { selectedNodeId } = buildDeleteResult;
-
-  const getReturnPayload = (selectionOffsets) => {
-    return { selectionOffsets, historyState };
+  // decide where to place the caret before altering the document state
+  // deleting from single node - if there's a selection is just caretStart, otherwise subtract 1 - don't go beyond 0
+  const executeSelectionOffsets = {
+    startNodeId,
+    caretStart,
   };
 
-  // edge case where user selects from end of line (no selected chars in first line) through a following line (didDeleteEndNode)
-  if (startDiffLength === 0 && didDeleteEndNode) {
-    return getReturnPayload({
+  // TODO: handle replacing MetaType node
+  // NOTE: this is unexpected for select-and-type or paste, better to just "clear" the node of all text
+  if (willDeleteStartNode && documentModel.isMetaType(startNodeId)) {
+  }
+  // delete one or more chars in TextType select-and-type, cut or paste
+  const diffLength = caretEnd - caretStart;
+  const historyState = [];
+  historyState.push(
+    ...documentModel.deleteNodeContentRangeAndUpdateSelections(
+      diffLength,
       startNodeId,
-      caretStart,
-    });
-  }
-
-  // NOTE: need to distinguish between collapsed caret backspace and highlight 1 char backspace
-  //  the former removes a character behind the caret and the latter removes one in front...
-  historyState.push(
-    ...updateNode(documentModel, startDiffLength, startNodeId, caretStart)
+      caretStart
+    )
   );
-  // getLastExecuteId == undefined means user selected and deleted all text in the node
-  selectedNodeId = documentModel.getLastInsertId() || startNodeId;
-
-  // if we deleted the first node in the document, use the node that documentModel.deleteNode() returns
-  if (selectedNodeId !== startNodeId) {
-    return getReturnPayload({
-      startNodeId: selectedNodeId,
-      caretStart: -1,
-    });
-  }
-
-  // After updating or deleting start/middle/end nodes - are we done (return here)? Or do we need to merge nodes?
-  // We're done if the user deleted the end node:
-  if (!endNodeId || didDeleteEndNode || startDiffLength === 0) {
-    return getReturnPayload({
-      startNodeId: selectedNodeId,
-      // startDiffLength === 0 means a collapsed caret backspace, decrement the caret position by 1
-      caretStart: startDiffLength === 0 ? caretStart - 1 : caretStart,
-    });
-  }
-
-  // if we're here, the end node needs to be merged into the start node
-  return getReturnPayload({ startNodeId: endNodeId, caretStart: 0 });
+  return { historyState, selectionOffsets: executeSelectionOffsets };
 }
 
-/**
- * MERGING NODES AFTER DELETE...
- *
- *  UPDATE: immutablejs has helped make this situation more predictable but,
- *  it still isn't conducive to an undo/redo workflow, so leaving the TODO
- *
- *  UPDATE 2: this is a lot more stable after grouping handlers by Node Types.
- *  Splitting out the "DocumentModel" and the "HistoryManager" concerns will help enable undo/redo history.
- *  This will all be revisited during undo/redo.
- *
- *  UPDATE 3: wow, so much easier using a linked list data structure to represent the document, le sigh 🤦‍♀️
- */
-export function doMerge(documentModel, selectionOffsets) {
-  assertValidDomSelectionOrThrow(selectionOffsets);
-  // eslint-disable-next-line prefer-const
-  let { caretStart, startNodeId } = selectionOffsets;
-  const selectedNodeId = startNodeId;
-  const historyState = [];
-  const getReturnPayload = (selectionOffsets) => {
-    return { selectionOffsets, historyState };
-  };
-
-  if (documentModel.isMetaType(selectedNodeId)) {
-    /* eslint-disable-next-line no-param-reassign */
-    startNodeId = documentModel.getPrevNode(selectedNodeId).get('id');
-    // focus end of previous node
-    /* eslint-disable-next-line no-param-reassign */
-    caretStart = -1;
-    historyState.push(
-      ...documentModel.deleteNode(documentModel.getNode(selectedNodeId))
-    );
-    return getReturnPayload({ startNodeId, caretStart });
-  }
-  /* eslint-disable-next-line no-param-reassign */
-  const prevNode = documentModel.getPrevNode(selectedNodeId);
-  const prevNodeId = prevNode.get('id');
-  // if at beginning of first node, nothing to do
-  if (!prevNodeId) {
-    return getReturnPayload({ startNodeId: selectedNodeId });
-  }
-  if (!documentModel.isTextType(prevNodeId)) {
-    // delete an empty TextType node
-    const maybeEmptyNode = documentModel.getNode(selectedNodeId);
-    if (maybeEmptyNode.get('content').length === 0) {
-      historyState.push(...documentModel.deleteNode(maybeEmptyNode));
-    }
-    return getReturnPayload({ startNodeId: prevNodeId, caretStart: 0 });
-  }
-  // optionally merges Selections
-  historyState.push(
-    ...documentModel.mergeParagraphs(prevNodeId, selectedNodeId)
+export function doDeleteSingleNodeBackspace(
+  documentModel,
+  historyManager,
+  selectionOffsets
+) {
+  const { startNodeId, caretStart, caretEnd } = selectionOffsets;
+  const caretIsCollapsed = isCollapsed(selectionOffsets);
+  const { willDeleteStartNode } = documentModel.willDeleteStartAndEnd(
+    selectionOffsets
   );
-  return getReturnPayload({
-    startNodeId: prevNodeId,
-    caretStart: prevNode.get('content').length,
+  const startNode = documentModel.getNode(startNodeId);
+  const startPrevNode = documentModel.getPrevNode(startNodeId);
+  const startNodeWasFirstNode = startPrevNode.isEmpty();
+  let executeSelectionOffsets;
+
+  console.debug('Delete - SINGLE NODE');
+
+  // decide where to place the caret before altering the document state
+  if (caretIsCollapsed && caretStart === 0 && !startNodeWasFirstNode) {
+    // delete or merge previous node, if not first node
+    const caretStartPrev = documentModel.isMetaType(startPrevNode.get('id'))
+      ? 0
+      : cleanText(startPrevNode.get('content')).length;
+    // focus prev MetaType or prev TextType content length (before merge)
+    executeSelectionOffsets = {
+      startNodeId: startPrevNode.get('id'),
+      caretStart: caretStartPrev,
+    };
+  } else {
+    // deleting from single node - if there's a selection is just caretStart, otherwise subtract 1 - don't go beyond 0
+    const caretStartAfterDelete = caretIsCollapsed
+      ? Math.max(caretStart - 1, 0)
+      : caretStart;
+    executeSelectionOffsets = {
+      startNodeId,
+      caretStart: caretStartAfterDelete,
+    };
+  }
+
+  // delete MetaType node or all of a TextType node
+  // NOTE: this is unexpected for select-and-type or paste, better to just "clear" the node of all text
+  if (willDeleteStartNode) {
+    const historyState = documentModel.deleteNode(startNode);
+    historyManager.appendToHistoryLog({
+      historyState,
+      selectionOffsets: executeSelectionOffsets,
+    });
+    return { historyState, selectionOffsets: executeSelectionOffsets };
+  }
+  // caret collapsed - at beginning of TextType node (merge with prev TextType or delete prev MetaType node)
+  if (caretIsCollapsed && caretStart === 0) {
+    const historyState = [];
+    if (startNodeWasFirstNode) {
+      // first node in the document - ignore
+      return { historyState, selectionOffsets: executeSelectionOffsets };
+    }
+    if (documentModel.isMetaType(startPrevNode.get('id'))) {
+      // delete the previous MetaType node
+      historyState.push(...documentModel.deleteNode(startPrevNode));
+    } else {
+      // merge with the previous TextType node
+      historyState.push(
+        ...documentModel.mergeParagraphs(startPrevNode.get('id'), startNodeId)
+      );
+    }
+    historyManager.appendToHistoryLog({
+      historyState,
+      selectionOffsets: executeSelectionOffsets,
+    });
+    return { historyState, selectionOffsets: executeSelectionOffsets };
+  }
+  // delete one or more chars in TextType (collapsed caret backspace or highlight-and-backspace in one node)
+  // NOTE: for collapsed caret - pass a diffLength of 0, other functions will understand it as "delete one char to the left of the caret"
+  const diffLength = caretEnd - caretStart;
+  const historyState = [];
+  historyState.push(
+    ...documentModel.deleteNodeContentRangeAndUpdateSelections(
+      diffLength,
+      startNodeId,
+      caretStart
+    )
+  );
+  historyManager.appendToHistoryLogWhenNCharsAreDifferent({
+    historyState,
+    selectionOffsets: executeSelectionOffsets,
+    comparisonPath: ['content'],
   });
+  return { historyState, selectionOffsets: executeSelectionOffsets };
+}
+
+export function doDeleteMultiNode(
+  documentModel,
+  historyManager,
+  selectionOffsets
+) {
+  const { startNodeId, endNodeId, caretStart, caretEnd } = selectionOffsets;
+  const {
+    willDeleteStartNode,
+    willDeleteEndNode,
+  } = documentModel.willDeleteStartAndEnd(selectionOffsets);
+  const startNode = documentModel.getNode(startNodeId);
+  const historyState = [];
+
+  console.debug('Delete - MULTI NODE');
+
+  // for non-merge delete operations, always focus the beginning of the selection
+  const executeSelectionOffsets = { startNodeId, caretStart };
+
+  // delete any middle nodes
+  documentModel.getNodesBetween(startNodeId, endNodeId).forEach((node) => {
+    console.info('delete middle node', node.toJS());
+    historyState.push(...documentModel.deleteNode(node));
+  });
+
+  // delete startNode
+  historyState.push(
+    ...documentModel.deleteNodeContentRangeAndUpdateSelections(
+      startNode.get('content').length - caretStart,
+      startNodeId,
+      caretStart
+    )
+  );
+
+  // delete endNode
+  const endNode = documentModel.getNode(endNodeId);
+  if (willDeleteEndNode) {
+    historyState.push(...documentModel.deleteNode(endNode));
+  } else if (caretEnd > 0) {
+    // TODO: since functions called later on expect a diffLength === 0 to mean "delete one char in front of the caret"
+    //  we need to make sure not to call this for select-and-type or paste operations...
+    historyState.push(
+      ...documentModel.deleteNodeContentRangeAndUpdateSelections(
+        caretEnd,
+        endNodeId,
+        0
+      )
+    );
+  }
+
+  // merge? the only merge scenario is when both are text and both weren't deleted
+  const startNodeAndEndNodeAreTextType =
+    documentModel.isTextType(startNodeId) &&
+    documentModel.isTextType(endNodeId);
+  if (
+    !(willDeleteStartNode && willDeleteEndNode) &&
+    startNodeAndEndNodeAreTextType
+  ) {
+    historyState.push(...documentModel.mergeParagraphs(startNodeId, endNodeId));
+  }
+
+  return { historyState, selectionOffsets: executeSelectionOffsets };
+}
+
+export function doDeleteMultiNodeBackspace(
+  documentModel,
+  historyManager,
+  selectionOffsets
+) {
+  const { startNodeId, endNodeId, caretStart, caretEnd } = selectionOffsets;
+  const {
+    willDeleteStartNode,
+    willDeleteEndNode,
+  } = documentModel.willDeleteStartAndEnd(selectionOffsets);
+  const startNode = documentModel.getNode(startNodeId);
+  const startPrevNode = documentModel.getPrevNode(startNodeId);
+  const startNodeWasFirstNode = startPrevNode.isEmpty();
+  let executeSelectionOffsets;
+  const historyState = [];
+
+  console.debug('Delete - MULTI NODE');
+
+  // decide where to place the caret before altering the document state
+  const endNextNode = documentModel.getNextNode(endNodeId);
+  const endNodeWasLastNode = endNextNode.isEmpty();
+  if (willDeleteStartNode) {
+    if (willDeleteEndNode) {
+      if (startNodeWasFirstNode) {
+        if (endNodeWasLastNode) {
+          // deleted all nodes in the document - startNode will have been transformed into a placeholder title - focus startNode at position 0
+          executeSelectionOffsets = { startNodeId, caretStart: 0 };
+        } else {
+          // deleted through the top of the document - focus node after endNode
+          executeSelectionOffsets = {
+            startNodeId: endNextNode.get('id'),
+            caretStart: 0,
+          };
+        }
+      } else {
+        // deleted start and end
+        executeSelectionOffsets = {
+          startNodeId: startPrevNode.get('id'),
+          caretStart: -1,
+        };
+      }
+    } else {
+      // deleted start node and part of end node - focus end node at beginning
+      executeSelectionOffsets = { startNodeId: endNodeId, caretStart: 0 };
+    }
+  } else {
+    // didn't delete all of startNode - focus caretStart since we're deleting up to it
+    executeSelectionOffsets = { startNodeId, caretStart };
+  }
+
+  // delete any middle nodes
+  documentModel.getNodesBetween(startNodeId, endNodeId).forEach((node) => {
+    console.info('delete middle node', node.toJS());
+    historyState.push(...documentModel.deleteNode(node));
+  });
+
+  // delete startNode
+  if (willDeleteStartNode) {
+    historyState.push(...documentModel.deleteNode(startNode));
+  } else {
+    historyState.push(
+      ...documentModel.deleteNodeContentRangeAndUpdateSelections(
+        startNode.get('content').length - caretStart,
+        startNodeId,
+        caretStart
+      )
+    );
+  }
+
+  // delete endNode
+  const endNode = documentModel.getNode(endNodeId);
+  if (willDeleteEndNode) {
+    historyState.push(...documentModel.deleteNode(endNode));
+  } else {
+    historyState.push(
+      ...documentModel.deleteNodeContentRangeAndUpdateSelections(
+        caretEnd,
+        endNodeId,
+        0
+      )
+    );
+  }
+
+  // merge? the only merge scenario is when both are text and both weren't deleted
+  const startNodeAndEndNodeAreTextType =
+    documentModel.isTextType(startNodeId) &&
+    documentModel.isTextType(endNodeId);
+  if (
+    !(willDeleteStartNode && willDeleteEndNode) &&
+    startNodeAndEndNodeAreTextType
+  ) {
+    historyState.push(...documentModel.mergeParagraphs(startNodeId, endNodeId));
+  }
+
+  historyManager.appendToHistoryLog({
+    selectionOffsets: executeSelectionOffsets,
+    historyState,
+  });
+
+  return { historyState, selectionOffsets: executeSelectionOffsets };
 }

--- a/web/src/editor-components/event-handlers/backspace.js
+++ b/web/src/editor-components/event-handlers/backspace.js
@@ -1,7 +1,10 @@
 import { Map } from 'immutable';
 import { KEYCODE_BACKSPACE } from '@filbert/constants';
 import { stopAndPrevent } from '../../common/utils';
-import { doDelete, doDeleteMetaType, doMerge } from '../editor-commands/delete';
+import {
+  doDeleteSingleNodeBackspace,
+  doDeleteMultiNodeBackspace,
+} from '../../editor-components/editor-commands/delete';
 
 export async function handleBackspace({
   evt,
@@ -15,80 +18,38 @@ export async function handleBackspace({
   // otherwise, if there are any other key strokes that aren't control keys - delete the selection!
   if (
     evt.keyCode !== KEYCODE_BACKSPACE &&
-    evt.inputType !== 'deleteContentBackward'
+    evt.inputType !== 'deleteContentBackward' &&
+    evt.inputType !== 'deleteByCut'
   ) {
     return false;
   }
 
   stopAndPrevent(evt);
 
-  const { startNodeId, endNodeId, caretStart, caretEnd } = selectionOffsets;
+  const { endNodeId } = selectionOffsets;
 
-  const historyState = [];
-  let executeSelectionOffsets = selectionOffsets;
-
-  // is this a MetaType node?
-  if (documentModel.isMetaType(startNodeId)) {
+  // SINGLE NODE
+  if (!endNodeId) {
     const {
-      historyState: historyStateDeleteMetaType,
-      selectionOffsets: executeSelectionOffsetsDeleteMetaType,
-    } = doDeleteMetaType(documentModel, selectionOffsets);
-    historyState.push(...historyStateDeleteMetaType);
-    executeSelectionOffsets = executeSelectionOffsetsDeleteMetaType;
-
-    historyManager.appendToHistoryLog({
       selectionOffsets: executeSelectionOffsets,
-      historyState,
-    });
-    // call this setter before commitUpdates or it could unset a neighboring meta node highlight!
+    } = doDeleteSingleNodeBackspace(
+      documentModel,
+      historyManager,
+      selectionOffsets
+    );
     setEditSectionNode(Map());
     await commitUpdates(executeSelectionOffsets);
     return true;
   }
 
-  const hasContentToDelete = endNodeId || caretStart > 0 || caretEnd;
-
-  // is there any content to delete?
-  if (hasContentToDelete) {
-    const {
-      historyState: historyStateDelete,
-      selectionOffsets: executeSelectionOffsetsDelete,
-    } = doDelete(documentModel, selectionOffsets);
-    historyState.push(...historyStateDelete);
-    executeSelectionOffsets = executeSelectionOffsetsDelete;
-  }
-
-  // if doDelete() returns a different startNodeId, a merge is required
-  // TODO: verify highlight + cut or delete has the right behavior
-  const needsMergeWithOtherNode =
-    executeSelectionOffsets.startNodeId !== startNodeId ||
-    (!caretStart && !caretEnd);
-
-  if (needsMergeWithOtherNode) {
-    const {
-      selectionOffsets: executeSelectionOffsetsMerge,
-      historyState: historyStateMerge,
-    } = doMerge(documentModel, executeSelectionOffsets);
-    historyState.push(...historyStateMerge);
-    executeSelectionOffsets = executeSelectionOffsetsMerge;
-  }
-
-  // since this handler catches keystrokes *before* DOM updates, deleting one char will look like a diff length of 0
-  const didDeleteContentInOneNode = !endNodeId && hasContentToDelete;
-
-  if (didDeleteContentInOneNode) {
-    historyManager.appendToHistoryLogWhenNCharsAreDifferent({
-      selectionOffsets: executeSelectionOffsets,
-      historyState,
-      comparisonPath: ['content'],
-    });
-  } else {
-    historyManager.appendToHistoryLog({
-      selectionOffsets: executeSelectionOffsets,
-      historyState,
-    });
-  }
-
+  // MULTI-NODE
+  const {
+    selectionOffsets: executeSelectionOffsets,
+  } = doDeleteMultiNodeBackspace(
+    documentModel,
+    historyManager,
+    selectionOffsets
+  );
   // clear the selected format node when deleting the highlighted selection
   // NOTE: must wait for state to have been set or setCaret will check stale values
   await commitUpdates(executeSelectionOffsets);

--- a/web/src/editor-components/event-handlers/redo.js
+++ b/web/src/editor-components/event-handlers/redo.js
@@ -1,7 +1,7 @@
 import { Map } from 'immutable';
 import { KEYCODE_Z } from '@filbert/constants';
 import { stopAndPrevent } from '../../common/utils';
-import { currentPost } from "../../stores";
+import { currentPost } from '../../stores';
 
 export function isRedoEvent(evt) {
   return (

--- a/web/src/editor-components/event-handlers/undo.js
+++ b/web/src/editor-components/event-handlers/undo.js
@@ -1,7 +1,7 @@
 import { Map } from 'immutable';
 import { KEYCODE_Z } from '@filbert/constants';
 import { stopAndPrevent } from '../../common/utils';
-import { currentPost } from "../../stores";
+import { currentPost } from '../../stores';
 
 export function isUndoEvent(evt) {
   return evt.keyCode === KEYCODE_Z && (evt.metaKey || evt.ctrlKey);

--- a/web/src/routes/edit/[post].svelte
+++ b/web/src/routes/edit/[post].svelte
@@ -188,7 +188,7 @@
       });
       // Sapper calls document.activeElement.blur() on navigation for some reason...
       tick().then(() => {
-        commitUpdates(selectionOffsets)
+        commitUpdates(selectionOffsets);
       });
       return;
     }
@@ -471,6 +471,9 @@
         documentModel,
         historyManager,
         commitUpdates,
+        setEditSectionNode: (value) => {
+          editSectionNode = value;
+        },
       });
       return;
     }
@@ -620,7 +623,13 @@
   // TODO: show/hide logic for this menu is split up and difficult to understand.
   //  It should be split up based on type of event instead of trying to overload the handlers with too much logic
   async function manageFormatSelectionMenu(evt, selectionOffsets) {
+    // allow user to hold shift and use arrow keys to adjust selection range
     if (evt.shiftKey) {
+      return;
+    }
+    // FormatSelectionMenu has event handlers that interfere with cut / paste
+    if (isCutEvent(evt) || isPasteEvent(evt)) {
+      closeFormatSelectionMenu();
       return;
     }
     const { caretStart, caretEnd, startNodeId, endNodeId } = selectionOffsets;
@@ -645,17 +654,13 @@
         '// TODO: format selection across nodes: ',
         selectionOffsets
       );
+      // NOTE: unset this selectionOffsets cache - another issue is you can't select across multiple nodes for cut/paste - this value will setCaret() to a stale value
+      selectionOffsetsManageFormatSelectionMenu = undefined;
       closeFormatSelectionMenu();
       return;
     }
 
-    // allow user to hold shift and use arrow keys to adjust selection range
-    if (
-      !evt.shiftKey &&
-      !(evt.metaKey && [KEYCODE_X, KEYCODE_V].includes(evt.keyCode))
-    ) {
-      stopAndPrevent(evt);
-    }
+    stopAndPrevent(evt);
 
     const range = getRange();
     const rect = range.getBoundingClientRect();

--- a/web/src/routes/edit/[post].svelte
+++ b/web/src/routes/edit/[post].svelte
@@ -246,15 +246,8 @@
       return;
     }
     console.info('CREATE NEW POST');
-    // copy placeholder history
-    const pendingHistory = historyManager.getLocalHistoryLog();
-    // re-instantiate HistoryManager with pendingHistory for saveAndClearLocalHistoryLog()
-    // will save current document state from history
-    await HistoryManager(
-      postId,
-      apiClient,
-      pendingHistory
-    ).saveAndClearLocalHistoryLog();
+    // will save current document state from history with the newly created postId
+    await historyManager.saveAndClearLocalHistoryLog(postId);
     // huh, aren't we on /edit? - this is for going from /edit/new -> /edit/123...
     await goto(`/edit/${postId}`, { replaceState: true });
   }


### PR DESCRIPTION
Seems to work, all tests are broken

Split functionality into single vs multi-node selection and backspace (which has extra delete & merge behavior) and non-backspace (select-and-type, cut & paste) helpers - 4 helpers in total.

Basically, the code had changed enough that the old `doDelete()` and `doMerge()` helpers a) weren't correct anymore and b) were really difficult to understand.  The new refactor splits those into 4 helpers and also separates the "decide where the caret will go after the operation is finished" logic from the actual document manipulation.  I think this is better and easier to understand and add more logic to for inevitable future edge cases.  

It's certainly not elegant, there must be a way to abstract and separate concerns such that some of these edge cases are handled in the nominal case but, I haven't found it yet.  There are a few dimensions of behavior logic to consider:
- hitting backspace vs "replace" for select-and-type, cut & paste
- delete is atomic and should be added as a separate history item OR delete is composed as part of a larger atomic operation like select-and-type, cut & paste
- deleting one character should be queued until the "minimum diff size threshold" - in other words, not every delete should have a history entry necessarily.  Queuing history entry candidates should be handled internally by the historyLog, consumers shouldn't have to know about it - this one is easy to fix and eliminate. 
- given capture at `keydown` or "before" state change - hitting backspace with a collapsed caret is represented as a diff length of 0 - this needs to be translated into "delete one character to the left of the caret" OR merge OR delete if MetaType node is previous node
- can't paste into a MetaType node - should it be converted into a paragraph?  should it be deleted?  ignored and kept?

Clearly, some of this logic is the result of my implementation and wouldn't need to be considered given a different approach.  Maybe I'll get there some day, maybe not :) 